### PR TITLE
Add -rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Or you can just dump `dash.el` in your load path somewhere.
 * [-take-while](#-take-while-pred-list) `(pred list)`
 * [-drop-while](#-drop-while-pred-list) `(pred list)`
 * [-split-at](#-split-at-n-list) `(n list)`
+* [-rotate](#-rotate-n-list) `(n list)`
 * [-insert-at](#-insert-at-n-x-list) `(n x list)`
 * [-split-with](#-split-with-pred-list) `(pred list)`
 * [-separate](#-separate-pred-list) `(pred list)`
@@ -500,6 +501,16 @@ Returns a list of ((-take `n` `list`) (-drop `n` `list`)), in no more than one p
 ```cl
 (-split-at 3 '(1 2 3 4 5)) ;; => '((1 2 3) (4 5))
 (-split-at 17 '(1 2 3 4 5)) ;; => '((1 2 3 4 5) nil)
+```
+
+### -rotate `(n list)`
+
+Rotate `list` `n` places to the right.  With `n` negative, rotate to the left.
+The time complexity is `o`(n).
+
+```cl
+(-rotate 3 '(1 2 3 4 5 6 7)) ;; => '(5 6 7 1 2 3 4)
+(-rotate -3 '(1 2 3 4 5 6 7)) ;; => '(4 5 6 7 1 2 3)
 ```
 
 ### -insert-at `(n x list)`

--- a/dash.el
+++ b/dash.el
@@ -450,6 +450,13 @@ FROM or TO may be negative."
         (!cdr list)))
     (list (nreverse result) list)))
 
+(defun -rotate (n list)
+  "Rotate LIST N places to the right.  With N negative, rotate to the left.
+The time complexity is O(n)."
+  (if (> n 0)
+      (append (last list n) (butlast list n))
+    (append (-drop (- n) list) (-take (- n) list))))
+
 (defun -insert-at (n x list)
   "Returns a list with X inserted into LIST at position N."
   (let ((split-list (-split-at n list)))
@@ -1001,6 +1008,7 @@ Returns nil if N is less than 1."
                            "--drop-while"
                            "-drop-while"
                            "-split-at"
+                           "-rotate"
                            "-insert-at"
                            "--split-with"
                            "-split-with"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -199,6 +199,10 @@
   (-split-at 3 '(1 2 3 4 5)) => '((1 2 3) (4 5))
   (-split-at 17 '(1 2 3 4 5)) => '((1 2 3 4 5) nil))
 
+(defexamples -rotate
+  (-rotate 3 '(1 2 3 4 5 6 7)) => '(5 6 7 1 2 3 4)
+  (-rotate -3 '(1 2 3 4 5 6 7)) => '(4 5 6 7 1 2 3)) 
+
 (defexamples -insert-at
   (-insert-at 1 'x '(a b c)) => '(a x b c)
   (-insert-at 12 'x '(a b c)) => '(a b c x))


### PR DESCRIPTION
Simple yet useful, rotate the content of the list to the left or to the right.

Usecase: I used this in `elwm`, my "xmonad" clone for emacs (very very basic yet) to rotate/swap/transpose windows & buffers.
