### PR TITLE
Fix incorrect alias checking in docs--signature

### DIFF
--- a/dev/examples-to-docs.el
+++ b/dev/examples-to-docs.el
@@ -16,7 +16,7 @@
   "Given FUNCTION (a symbol), return its argument list.
 FUNCTION may reference an elisp function, alias, macro or a subr."
   (let* ((function-value (indirect-function function))
-         (is-alias (eq function-value (symbol-function function)))
+         (is-alias (not (eq function-value (symbol-function function))))
          ;; if FUNCTION isn't an alias, function-symbol is simply FUNCTION
          (function-symbol function))
     


### PR DESCRIPTION
help-split-fundoc expects the function symbol to be the function
name used in the docstring. Since we only use help-split-fundoc for
subrs, this isn't an issue in practice, because subrs use
`(fn some-arg some-other-arg)` rather than an explicit name.

Still, the boolean ought to do what it says it's doing.

(Ahem, sorry about this. Realised the code didn't do what I wanted it when I had another quick skim.)
