### PR TITLE
Add remove/modify functions for index/indices)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Include this in your emacs settings to get syntax highlighting:
 * [-drop-while](#-drop-while-pred-list) `(pred list)`
 * [-rotate](#-rotate-n-list) `(n list)`
 * [-insert-at](#-insert-at-n-x-list) `(n x list)`
+* [-replace-at](#-replace-at-n-x-list) `(n x list)`
+* [-update-at](#-update-at-n-func-list) `(n func list)`
+* [-remove-at](#-remove-at-n-list) `(n list)`
+* [-remove-at-indices](#-remove-at-indices-indices-list) `(indices list)`
 
 ### Reductions
 
@@ -382,6 +386,48 @@ Returns a list with `x` inserted into `list` at position `n`.
 ```cl
 (-insert-at 1 'x '(a b c)) ;; => '(a x b c)
 (-insert-at 12 'x '(a b c)) ;; => '(a b c x)
+```
+
+#### -replace-at `(n x list)`
+
+Return a list with element at Nth position in `list` replaced with `x`.
+
+```cl
+(-replace-at 0 9 '(0 1 2 3 4 5)) ;; => '(9 1 2 3 4 5)
+(-replace-at 1 9 '(0 1 2 3 4 5)) ;; => '(0 9 2 3 4 5)
+(-replace-at 4 9 '(0 1 2 3 4 5)) ;; => '(0 1 2 3 9 5)
+```
+
+#### -update-at `(n func list)`
+
+Return a list with element at Nth position in `list` replaced with `(func (nth n list))`.
+
+```cl
+(-update-at 0 (lambda (x) (+ x 9)) '(0 1 2 3 4 5)) ;; => '(9 1 2 3 4 5)
+(-update-at 1 (lambda (x) (+ x 8)) '(0 1 2 3 4 5)) ;; => '(0 9 2 3 4 5)
+(--update-at 2 (length it) '("foo" "bar" "baz" "quux")) ;; => '("foo" "bar" 3 "quux")
+```
+
+#### -remove-at `(n list)`
+
+Return a list with element at Nth position in `list` removed.
+
+```cl
+(-remove-at 0 '("0" "1" "2" "3" "4" "5")) ;; => '("1" "2" "3" "4" "5")
+(-remove-at 1 '("0" "1" "2" "3" "4" "5")) ;; => '("0" "2" "3" "4" "5")
+(-remove-at 2 '("0" "1" "2" "3" "4" "5")) ;; => '("0" "1" "3" "4" "5")
+```
+
+#### -remove-at-indices `(indices list)`
+
+Return a list whose elements are elements from `list` without
+elements selected as `(nth i list)` for all i
+from `indices`.
+
+```cl
+(-remove-at-indices '(0) '("0" "1" "2" "3" "4" "5")) ;; => '("1" "2" "3" "4" "5")
+(-remove-at-indices '(0 2 4) '("0" "1" "2" "3" "4" "5")) ;; => '("1" "3" "5")
+(-remove-at-indices '(0 5) '("0" "1" "2" "3" "4" "5")) ;; => '("1" "2" "3" "4")
 ```
 
 

--- a/dash.el
+++ b/dash.el
@@ -469,6 +469,38 @@ The time complexity is O(n)."
   (let ((split-list (-split-at n list)))
     (nconc (car split-list) (cons x (cadr split-list)))))
 
+(defun -replace-at (n x list)
+  "Return a list with element at Nth position in LIST replaced with X."
+  (let ((split-list (-split-at n list)))
+    (nconc (car split-list) (cons x (cdr (cadr split-list))))))
+
+(defun -update-at (n func list)
+  "Return a list with element at Nth position in LIST replaced with `(func (nth n list))`."
+  (let ((split-list (-split-at n list)))
+    (nconc (car split-list) (cons (funcall func (car (cadr split-list))) (cdr (cadr split-list))))))
+
+(defmacro --update-at (n form list)
+  "Anaphoric version of `-update-at'."
+  `(-update-at ,n (lambda (it) ,form) ,list))
+
+(defun -remove-at (n list)
+  "Return a list with element at Nth position in LIST removed."
+  (-remove-at-indices (list n) list))
+
+(defun -remove-at-indices (indices list)
+  "Return a list whose elements are elements from LIST without
+elements selected as `(nth i list)` for all i
+from INDICES."
+  (let* ((indices (-sort '< indices))
+         (diffs (cons (car indices) (-map '1- (-zip-with '- (cdr indices) indices))))
+         r)
+    (--each diffs
+      (let ((split (-split-at it list)))
+        (!cons (car split) r)
+        (setq list (cdr (cadr split)))))
+    (!cons list r)
+    (-flatten (nreverse r))))
+
 (defmacro --split-with (pred list)
   "Anaphoric form of `-split-with'."
   (let ((l (make-symbol "list"))
@@ -1172,6 +1204,11 @@ structure such as plist or alist."
                              "-split-at"
                              "-rotate"
                              "-insert-at"
+                             "-replace-at"
+                             "-update-at"
+                             "--update-at"
+                             "-remove-at"
+                             "-remove-at-indices"
                              "--split-with"
                              "-split-with"
                              "-partition"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -90,6 +90,42 @@
     (-insert-at 1 'x '(a b c)) => '(a x b c)
     (-insert-at 12 'x '(a b c)) => '(a b c x)))
 
+(defexamples -replace-at
+  (-replace-at 0 9 '(0 1 2 3 4 5)) => '(9 1 2 3 4 5)
+  (-replace-at 1 9 '(0 1 2 3 4 5)) => '(0 9 2 3 4 5)
+  (-replace-at 4 9 '(0 1 2 3 4 5)) => '(0 1 2 3 9 5)
+  (-replace-at 5 9 '(0 1 2 3 4 5)) => '(0 1 2 3 4 9))
+
+(defexamples -update-at
+  (-update-at 0 (lambda (x) (+ x 9)) '(0 1 2 3 4 5)) => '(9 1 2 3 4 5)
+  (-update-at 1 (lambda (x) (+ x 8)) '(0 1 2 3 4 5)) => '(0 9 2 3 4 5)
+  (--update-at 2 (length it) '("foo" "bar" "baz" "quux")) => '("foo" "bar" 3 "quux")
+  (--update-at 2 (concat it "zab") '("foo" "bar" "baz" "quux")) => '("foo" "bar" "bazzab" "quux"))
+
+(defexamples -remove-at
+  (-remove-at 0 '("0" "1" "2" "3" "4" "5")) => '("1" "2" "3" "4" "5")
+  (-remove-at 1 '("0" "1" "2" "3" "4" "5")) => '("0" "2" "3" "4" "5")
+  (-remove-at 2 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "3" "4" "5")
+  (-remove-at 3 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "4" "5")
+  (-remove-at 4 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "5")
+  (-remove-at 5 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "4"))
+
+(defexamples -remove-at-indices
+  (-remove-at-indices '(0) '("0" "1" "2" "3" "4" "5")) => '("1" "2" "3" "4" "5")
+  (-remove-at-indices '(0 2 4) '("0" "1" "2" "3" "4" "5")) => '("1" "3" "5")
+  (-remove-at-indices '(0 5) '("0" "1" "2" "3" "4" "5")) => '("1" "2" "3" "4")
+  (-remove-at-indices '(1 2 3) '("0" "1" "2" "3" "4" "5")) => '("0" "4" "5")
+  (-remove-at-indices '(0 1 2 3 4 5) '("0" "1" "2" "3" "4" "5")) => nil
+  (-remove-at-indices '(2 0 4) '("0" "1" "2" "3" "4" "5")) => '("1" "3" "5")
+  (-remove-at-indices '(5 0) '("0" "1" "2" "3" "4" "5")) => '("1" "2" "3" "4")
+  (-remove-at-indices '(1 3 2) '("0" "1" "2" "3" "4" "5")) => '("0" "4" "5")
+  (-remove-at-indices '(0 3 4 2 5 1) '("0" "1" "2" "3" "4" "5")) => nil
+  (-remove-at-indices '(1) '("0" "1" "2" "3" "4" "5")) => '("0" "2" "3" "4" "5")
+  (-remove-at-indices '(2) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "3" "4" "5")
+  (-remove-at-indices '(3) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "4" "5")
+  (-remove-at-indices '(4) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "5")
+  (-remove-at-indices '(5) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "4"))
+
 (def-example-group "Reductions" nil
   (defexamples -reduce-from
     (-reduce-from '- 10 '(1 2 3)) => 4


### PR DESCRIPTION
Patch provides 4 functions
- `modify-at`: replace element at index with new element
- `modify-with`: replace element at index with result of funciton `(a -> b)` with old element as input
- `remove-at`: remove element at index (how come this didn't exist yet, after a year! :D)
- `remove-at-indices`: remove elements at indices.
