### PR TITLE
Add -snoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Include this in your emacs settings to get syntax highlighting:
 
 * [-repeat](#-repeat-n-x) `(n x)`
 * [-cons*](#-cons-rest-args) `(&rest args)`
+* [-snoc](#-snoc-list-elem-rest-elements) `(list elem &rest elements)`
 * [-interpose](#-interpose-sep-list) `(sep list)`
 * [-interleave](#-interleave-rest-lists) `(&rest lists)`
 * [-zip-with](#-zip-with-fn-list1-list2) `(fn list1 list2)`
@@ -864,6 +865,20 @@ a dotted list.
 (-cons* 1 2) ;; => '(1 . 2)
 (-cons* 1 2 3) ;; => '(1 2 . 3)
 (-cons* 1) ;; => 1
+```
+
+#### -snoc `(list elem &rest elements)`
+
+Append `elem` to the end of the list.
+
+This is like `cons`, but operates on the end of list.
+
+If `elements` is non nil, append these to the list as well.
+
+```cl
+(-snoc '(1 2 3) 4) ;; => '(1 2 3 4)
+(-snoc '(1 2 3) 4 5 6) ;; => '(1 2 3 4 5 6)
+(-snoc '(1 2 3) '(4 5 6)) ;; => '(1 2 3 (4 5 6))
 ```
 
 #### -interpose `(sep list)`

--- a/dash.el
+++ b/dash.el
@@ -275,6 +275,14 @@ a dotted list."
         (setq res (cons res it)))))
     res))
 
+(defun -snoc (list elem &rest elements)
+  "Append ELEM to the end of the list.
+
+This is like `cons', but operates on the end of list.
+
+If ELEMENTS is non nil, append these to the list as well."
+  (-concat list (list elem) elements))
+
 (defmacro --first (form list)
   "Anaphoric form of `-first'."
   (let ((n (make-symbol "needle")))
@@ -1225,6 +1233,7 @@ structure such as plist or alist."
                              "-contains-p"
                              "-repeat"
                              "-cons*"
+                             "-snoc"
                              "-sum"
                              "-product"
                              "-min"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -304,6 +304,11 @@
     (-cons* 1 2 3) => '(1 2 . 3)
     (-cons* 1) => 1)
 
+  (defexamples -snoc
+    (-snoc '(1 2 3) 4) => '(1 2 3 4)
+    (-snoc '(1 2 3) 4 5 6) => '(1 2 3 4 5 6)
+    (-snoc '(1 2 3) '(4 5 6)) => '(1 2 3 (4 5 6)))
+
   (defexamples -interpose
     (-interpose "-" '()) => '()
     (-interpose "-" '("a")) => '("a")


### PR DESCRIPTION
This is like cons but on the end of the list. Useful. And look at this:

``` lisp
(defmacro ->> (init &rest forms)
  (-reduce-r '-snoc (reverse (cons init forms))))
```

isn't it pretty? :package: 

(by the way, if you've never seen it, `snoc` (= cons backwards) is a common CS jargon for lists that cons from backward, like `(((nil . 1) . 2) . 3)`, so that's where it comes from)
