### PR TITLE
Add Cask-file.

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,0 +1,1 @@
+(package-file "dash.el")


### PR DESCRIPTION
Can you please merge this. Even though the package itself does not need the `Cask`-file, the upcoming `link` command in Cask requires a `Cask`-file.
