### PR TITLE
Fix bug with nested lists in `-remove-at-indices`

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -524,7 +524,7 @@ from INDICES."
         (!cons (car split) r)
         (setq list (cdr (cadr split)))))
     (!cons list r)
-    (-flatten (nreverse r))))
+    (apply '-concat (nreverse r))))
 
 (defmacro --split-with (pred list)
   "Anaphoric form of `-split-with'."

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -108,7 +108,9 @@
   (-remove-at 2 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "3" "4" "5")
   (-remove-at 3 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "4" "5")
   (-remove-at 4 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "5")
-  (-remove-at 5 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "4"))
+  (-remove-at 5 '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "4")
+  (-remove-at 5 '((a b) (c d) (e f g) h i ((j) k) l (m))) => '((a b) (c d) (e f g) h i l (m))
+  (-remove-at 0 '(((a b) (c d) (e f g) h i ((j) k) l (m)))) => nil)
 
 (defexamples -remove-at-indices
   (-remove-at-indices '(0) '("0" "1" "2" "3" "4" "5")) => '("1" "2" "3" "4" "5")
@@ -124,7 +126,11 @@
   (-remove-at-indices '(2) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "3" "4" "5")
   (-remove-at-indices '(3) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "4" "5")
   (-remove-at-indices '(4) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "5")
-  (-remove-at-indices '(5) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "4"))
+  (-remove-at-indices '(5) '("0" "1" "2" "3" "4" "5")) => '("0" "1" "2" "3" "4")
+  (-remove-at-indices '(1 2 4) '((a b) (c d) (e f g) h i ((j) k) l (m))) => '((a b) h ((j) k) l (m))
+  (-remove-at-indices '(5) '((a b) (c d) (e f g) h i ((j) k) l (m))) => '((a b) (c d) (e f g) h i l (m))
+  (-remove-at-indices '(0) '(((a b) (c d) (e f g) h i ((j) k) l (m)))) => nil
+  (-remove-at-indices '(2 3) '((0) (1) (2) (3) (4) (5) (6))) => '((0) (1) (4) (5) (6)))
 
 (def-example-group "Reductions" nil
   (defexamples -reduce-from


### PR DESCRIPTION
There is a pretty severe bug in the code I've contributed some time ago, namely `-remove-at-indices`---it breaks if applied to a list that contains lists: instead of removing the elements it will also flatten the entire list as a side effect of the implementation. This patch fixes this.

(what I wanted was to only "flatten it one level", but `-flatten` goes "all the way"... I'm thinking of adding a flatten that would only descend to a certain depth: could it be added as an optional argument to `-flatten` or do you think another function is needed?)
