### PR TITLE
Fix -cons*

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -280,17 +280,7 @@ Thus function FN should return a list."
 The last 2 members of ARGS are used as the final cons of the
 result so if the final member of ARGS is not a list the result is
 a dotted list."
-  (let (res)
-    (--each
-        args
-      (cond
-       ((not res)
-        (setq res it))
-       ((consp res)
-        (setcdr res (cons (cdr res) it)))
-       (t
-        (setq res (cons res it)))))
-    res))
+  (-reduce-r 'cons args))
 
 (defun -snoc (list elem &rest elements)
   "Append ELEM to the end of the list.

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -344,7 +344,9 @@
   (defexamples -cons*
     (-cons* 1 2) => '(1 . 2)
     (-cons* 1 2 3) => '(1 2 . 3)
-    (-cons* 1) => 1)
+    (-cons* 1) => 1
+    (-cons* 1 2 3 4) => '(1 2 3 . 4)
+    (apply '-cons* (number-sequence 1 10)) => '(1 2 3 4 5 6 7 8 9 . 10))
 
   (defexamples -snoc
     (-snoc '(1 2 3) 4) => '(1 2 3 4)


### PR DESCRIPTION
Seems like nobody used this ever, because it was broken for >3 arguments :P

I've just tried to use it to inplace prepend stuff in plists: `(setcdr list (-cons* ... (car list) (cdr list)))` then `(setcar list newcar)` but it broke on me. So here's the patch.
