### PR TITLE
Add -equal? function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Include this in your emacs settings to get syntax highlighting:
 * [-none?](#-none-pred-list) `(pred list)`
 * [-only-some?](#-only-some-pred-list) `(pred list)`
 * [-contains?](#-contains-list-element) `(list element)`
+* [-equal?](#-equal-list-list2) `(list list2)`
 
 ### Partitioning
 
@@ -618,6 +619,18 @@ or with `-compare-fn` if that's non-nil.
 (-contains? '(1 2 3) 1) ;; => t
 (-contains? '(1 2 3) 2) ;; => t
 (-contains? '(1 2 3) 4) ;; => nil
+```
+
+#### -equal? `(list list2)`
+
+Return true if `list` and `list2` has the same elements.
+
+The order of the elements in the lists does not matter.
+
+```cl
+(-equal? '(1 2 3) '(1 2 3)) ;; => t
+(-equal? '(1 2 3) '(3 2 1)) ;; => t
+(-equal? '(1 2 3) '(1 2 3 4)) ;; => nil
 ```
 
 

--- a/dash.el
+++ b/dash.el
@@ -964,6 +964,18 @@ or with `-compare-fn' if that's non-nil."
 
 (defalias '-contains-p '-contains?)
 
+(defun -equal? (list list2)
+  "Return true if LIST and LIST2 has the same elements.
+
+The order of the elements in the lists does not matter."
+  (let ((length-a (length list))
+        (length-b (length list2)))
+    (and
+     (= length-a length-b)
+     (= length-a (length (-intersection list list2))))))
+
+(defalias '-equal-p '-equal?)
+
 (defun -sort (comparator list)
   "Sort LIST, stably, comparing elements using COMPARATOR.
 Returns the sorted list.  LIST is NOT modified by side effects.
@@ -1284,6 +1296,8 @@ structure such as plist or alist."
                              "-difference"
                              "-contains?"
                              "-contains-p"
+                             "-equal?"
+                             "-equal-p"
                              "-sort"
                              "--sort"
                              "-repeat"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -226,7 +226,14 @@
     (-contains? '(1 2 3) 2) => t
     (-contains? '(1 2 3) 4) => nil
     (-contains? '() 1) => nil
-    (-contains? '() '()) => nil))
+    (-contains? '() '()) => nil)
+
+  (defexamples -equal?
+    (-equal? '(1 2 3) '(1 2 3)) => t
+    (-equal? '(1 2 3) '(3 2 1)) => t
+    (-equal? '(1 2 3) '(1 2 3 4)) => nil
+    (-equal? '((a . 1) (b . 2)) '((a . 1) (b . 2))) => t
+    (-equal? '(1 2 3) '(2 3 1)) => t))
 
 (def-example-group "Partitioning" nil
   (defexamples -split-at


### PR DESCRIPTION
Hi,

This pull request adds a function `-equal?` that returns true if two lists include the same elements, no matter of order.

I think this function should exist, but I'm not sure about the name. Another suggestion would be `-same?`. But I selected `-equal?` because it behaves similar to the built in `equal`.

What do you think?
