### PR TITLE
Add functions -setq and -let.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Include this in your emacs settings to get syntax highlighting:
 * [-when-let*](#-when-let-vars-vals-rest-body) `(vars-vals &rest body)`
 * [-if-let](#-if-let-var-val-then-rest-else) `(var-val then &rest else)`
 * [-if-let*](#-if-let-vars-vals-then-rest-else) `(vars-vals then &rest else)`
+* [-setq](#-setq-variables-values) `(variables values)`
+* [-let](#-let-varlist-rest-body) `(varlist &rest body)`
 
 ### Side-effects
 
@@ -1201,6 +1203,25 @@ If all `vals` evaluate to true, bind them to their corresponding
 ```cl
 (-if-let* ((x 5) (y 3) (z 7)) (+ x y z) "foo") ;; => 15
 (-if-let* ((x 5) (y nil) (z 7)) (+ x y z) "foo") ;; => "foo"
+```
+
+#### -setq `(variables values)`
+
+Set list of `variables` to list of `values`.
+
+```cl
+(progn (-setq (a b) '(1 2)) (list a b)) ;; => '(1 2)
+(let ((x '(3 4))) (-setq (c d) x) (list c d)) ;; => '(3 4)
+```
+
+#### -let `(varlist &rest body)`
+
+Set variables in `varlist` and yield `body`.
+
+```cl
+(progn (-let (((a b) '(1 2))) (list a b))) ;; => '(1 2)
+(progn (-let (((a b) '(1 2)) ((c d) '(3 4))) (list a b))) ;; => '(1 2)
+(let ((x '(3 4))) (-let (((c d) x)) (list c d))) ;; => '(3 4)
 ```
 
 

--- a/dash.el
+++ b/dash.el
@@ -913,6 +913,22 @@ otherwise do ELSE."
 (put '-if-let* 'lisp-indent-function 2)
 (put '--if-let 'lisp-indent-function 2)
 
+(defmacro -setq (variables values)
+  "Set list of VARIABLES to list of VALUES."
+  (cons
+   'progn
+   (-map-indexed
+    (lambda (index var)
+      `(setq ,var (nth ,index ,values)))
+    variables)))
+
+(defmacro -let (varlist &rest body)
+  "Set variables in VARLIST and yield BODY."
+  (declare (indent 1))
+  `(let ,(apply 'append (-map 'car varlist))
+     ,@(--map (cons '-setq it) varlist)
+     ,@body))
+
 (defun -distinct (list)
   "Return a new list with all duplicates removed.
 The test for equality is done with `equal',
@@ -1295,6 +1311,8 @@ structure such as plist or alist."
                              "-if-let"
                              "-if-let*"
                              "--if-let"
+                             "-setq"
+                             "-let"
                              "-distinct"
                              "-uniq"
                              "-union"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -496,7 +496,16 @@
 
   (defexamples -if-let*
     (-if-let* ((x 5) (y 3) (z 7)) (+ x y z) "foo") => 15
-    (-if-let* ((x 5) (y nil) (z 7)) (+ x y z) "foo") => "foo"))
+    (-if-let* ((x 5) (y nil) (z 7)) (+ x y z) "foo") => "foo")
+
+  (defexamples -setq
+    (progn (-setq (a b) '(1 2)) (list a b)) => '(1 2)
+    (let ((x '(3 4))) (-setq (c d) x) (list c d)) => '(3 4))
+
+  (defexamples -let
+    (progn (-let (((a b) '(1 2))) (list a b))) => '(1 2)
+    (progn (-let (((a b) '(1 2)) ((c d) '(3 4))) (list a b))) => '(1 2)
+    (let ((x '(3 4))) (-let (((c d) x)) (list c d))) => '(3 4)))
 
 (def-example-group "Side-effects" nil
   (defexamples -each


### PR DESCRIPTION
Hey,

Sometimes I work with key/value lists and I have to do:

```lisp
(let ((list
       '((foo "0.0.1")
         (bar "0.0.2")
         (baz "0.0.3")
         (qux "0.0.4"))))
  (-each list
    (lambda (item)
      (let ((name (car item))
            (version (cadr item)))
        (print name)
        (print version)))))
```

With this change, I can now do:

```lisp
(let ((list
       '((foo "0.0.1")
         (bar "0.0.2")
         (baz "0.0.3")
         (qux "0.0.4"))))
  (-each list
    (lambda (item)
      (-let (((name version) item))
        (print name)
        (print version)))))
```

This could be further extended with "pattern matching" support, like this:

```lisp
(-let (((_ &rest matches) (s-match "\\(.+\\)\\.\\(.+\\)" "foo.bar")))
  (print matches))
```

What do you think?