### PR TITLE
Fix fontification when there are dashes

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1397,9 +1397,9 @@ structure such as plist or alist."
                                   "acc"
                                   "other"
                                   )))
-         (font-lock-add-keywords 'emacs-lisp-mode `((,(concat "\\<" (regexp-opt special-variables 'paren) "\\>")
+         (font-lock-add-keywords 'emacs-lisp-mode `((,(concat "\\_<" (regexp-opt special-variables 'paren) "\\_>")
                                                      1 font-lock-variable-name-face)) 'append)
-         (font-lock-add-keywords 'emacs-lisp-mode `((,(concat "(\\s-*" (regexp-opt new-keywords 'paren) "\\>")
+         (font-lock-add-keywords 'emacs-lisp-mode `((,(concat "(\\s-*" (regexp-opt new-keywords 'paren) "\\_>")
                                                      1 font-lock-keyword-face)) 'append))
        (--each (buffer-list)
          (with-current-buffer it


### PR DESCRIPTION
In code like

```
(foo it-is-good)
```

"it" should not be fontified as special variable.
