### PR TITLE
Debug forms & --dotimes fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,7 +1371,7 @@ Returns nil, used for side-effects only.
 
 #### -dotimes `(num fn)`
 
-Repeatedly calls `fn` (presumably for side-effects) passing in integers from 0 through n-1.
+Repeatedly calls `fn` (presumably for side-effects) passing in integers from 0 through `num-1`.
 
 ```cl
 (let (s) (-dotimes 3 (lambda (n) (!cons n s))) s) ;; => '(2 1 0)

--- a/dash.el
+++ b/dash.el
@@ -92,16 +92,18 @@ Returns nil, used for side-effects only."
 (put '-each-while 'lisp-indent-function 2)
 
 (defmacro --dotimes (num &rest body)
-  "Repeatedly executes BODY (presumably for side-effects) with `it` bound to integers from 0 through n-1."
+  "Repeatedly executes BODY (presumably for side-effects) with `it` bound to integers from 0 through NUM-1."
   (declare (debug (form body))
            (indent 1))
-  `(let ((it 0))
-     (while (< it ,num)
-       ,@body
-       (setq it (1+ it)))))
+  (let ((n (make-symbol "num")))
+    `(let ((,n ,num)
+           (it 0))
+       (while (< it ,n)
+         ,@body
+         (setq it (1+ it))))))
 
 (defun -dotimes (num fn)
-  "Repeatedly calls FN (presumably for side-effects) passing in integers from 0 through n-1."
+  "Repeatedly calls FN (presumably for side-effects) passing in integers from 0 through NUM-1."
   (--dotimes num (funcall fn it)))
 
 (put '-dotimes 'lisp-indent-function 1)


### PR DESCRIPTION
Two patches in one because I'm lazy
1. Previously edebug couldn't step through the macro-forms, now it can (it's as if they were proper lambdas). I wasn't aware that `form` specification can do that, but apparently it can. I still can't fix `->>` though.
2. `--dotimes` evaluated the `num` argument `num` times, which is wrong if it's a form---it could even loop infinitely if it changed something by side effect.
