### PR TITLE
Improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: emacs-lisp
 before_install:
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
-    fi
-  - if [ "$EMACS" = 'emacs24' ]; then
-      sudo add-apt-repository -y ppa:cassou/emacs &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq
-          emacs24 emacs24-el emacs24-common-non-dfsg;
-    fi
+  # PPA for stable Emacs packages
+  - sudo add-apt-repository -y ppa:cassou/emacs
+  # PPA for Emacs nightlies
+  - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
+  # Update and install the Emacs for our environment
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -yy ${EMACS}-nox ${EMACS}-el
 env:
-  - EMACS=emacs
+  - EMACS=emacs23
   - EMACS=emacs24
   - EMACS=emacs-snapshot
 script:


### PR DESCRIPTION
Use the ubuntu-elisp PPA for nightly snapshot builds, as Cassou does not provide snapshot builds anymore, and simplify the installation of Emacs.
