### PR TITLE
Update dash.el

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1561,7 +1561,12 @@ Alias: `-uniq'"
 (defun -union (list list2)
   "Return a new list containing the elements of LIST1 and elements of LIST2 that are not in LIST1.
 The test for equality is done with `equal',
-or with `-compare-fn' if that's non-nil."
+or with `-compare-fn' if that's non-nil.
+
+In case one of the list is much shorter than the other, the performances will be better if `-union` 
+is called with first argument the long list, like:
+
+  (-union long-list short-list)"
   (let (result)
     (--each list (!cons it result))
     (--each list2 (unless (-contains? result it) (!cons it result)))


### PR DESCRIPTION
Hello,

I notice some big performance differences in calls of `-union` on my (rather slow) computer: computing the union of an empty list and a list with ~5000 elements takes about 1.5s, while computing the union of the same ~5000-long list and an empty list takes 0.02s.

The reason for that is clear by the implementation, and I don't think it should be changed. But I suggest a change in the docstring to make users aware of this phenomenon.

Note that other functions may show the same behavior, I only use a small subset of the library so I wouldn't know.

