### PR TITLE
Don't use an inline comment on a line of its own

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -901,8 +901,8 @@ of cons cells. Otherwise, return the groupings as a list of lists. "
       (setq lists (mapcar 'cdr lists)))
     (setq results (nreverse results))
     (if (= (length lists) 2)
-        ; to support backward compatability, return
-        ; a cons cell if two lists were provided
+        ;; to support backward compatability, return
+        ;; a cons cell if two lists were provided
         (--map (cons (car it) (cadr it)) results)
       results)))
 


### PR DESCRIPTION
`;` comments should be used only for inline comments (comments at the end of a line). Otherwise they are not properly indented in `emacs-lisp-mode`.
