### PR TITLE
Fix byte compilation test

### DIFF
--- a/dev/test-byte-compile.el
+++ b/dev/test-byte-compile.el
@@ -1,8 +1,0 @@
-(require 'ert)
-
-(ert-deftest dash-byte-compile ()
-  (let* ((cmd "emacs --quick --batch -f batch-byte-compile dash.el")
-         (res (shell-command-to-string cmd))
-         (elc (expand-file-name "dash.elc"))
-         (exp (format "Wrote %s\n" elc)))
-    (should (string= res exp))))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ -z "$EMACS" ] ; then
     EMACS="emacs"
 fi
@@ -10,5 +12,10 @@ $EMACS -batch \
        -l dash-functional.el \
        -l dev/examples-to-tests.el \
        -l dev/examples.el \
-       $([[ $EMACS != "emacs23" ]] && echo -l dev/test-byte-compile.el) \
        -f ert-run-tests-batch-and-exit
+
+if [[ $EMACS != "emacs23" ]]; then
+    $EMACS -Q --batch \
+           --eval '(setq byte-compile-error-on-warn t)' \
+           -f batch-byte-compile dash.el
+fi


### PR DESCRIPTION
The old test fails because `emacs-snapshot` doesn't output `Wrote dash.elc`. This should be more robust.