### PR TITLE
Add dir entry to texinfo template

### DIFF
--- a/dash-template.texi
+++ b/dash-template.texi
@@ -5,6 +5,10 @@
 @documentencoding UTF-8
 @documentlanguage en
 @syncodeindex fn cp
+@dircategory Emacs
+@direntry
+* Dash: (dash.info). A modern list library for GNU Emacs
+@end direntry
 @c %**end of header
 
 @copying


### PR DESCRIPTION
Small oops.  This is needed so doing `install-info foo/dash.info foo/dir` will actually add an entry to the dir file.