### PR TITLE
Allow run-tests.sh to skip tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,13 +6,23 @@ if [ -z "$EMACS" ] ; then
     EMACS="emacs"
 fi
 
+# Run all tests by default.
+# To only run certain tests, set $ERT_SELECTOR as required.
+# For example, to skip the test "-fixfn", run the following command:
+#
+# ERT_SELECTOR='(not "-fixfn")' ./run-tests.sh
+#
+if [ -z "$ERT_SELECTOR" ] ; then
+    ERT_SELECTOR="nil"
+fi
+
 $EMACS -batch \
        $([[ $EMACS == "emacs23" ]] && echo -l dev/ert.el) \
        -l dash.el \
        -l dash-functional.el \
        -l dev/examples-to-tests.el \
        -l dev/examples.el \
-       -f ert-run-tests-batch-and-exit
+       --eval "(ert-run-tests-batch-and-exit (quote ${ERT_SELECTOR}))"
 
 if [[ $EMACS != "emacs23" ]]; then
     $EMACS -Q --batch \


### PR DESCRIPTION
This a temporary fix on the way to a proper solution to #123, but I thought it would be of general use going forward, in case there are future tests that raise problems.

This change allows tests to be skipped for development purposes by setting the environment variable `ERT_SELECTOR' to a valid [ERT test selector](http://www.gnu.org/software/emacs/manual/html_node/ert/Test-Selectors.html#Test-Selectors), e.g.:
```
ERT_SELECTOR='(not "-fixfn")' ./run-tests.sh
```