### PR TITLE
Add `-some`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Other list functions not fit to be classified elsewhere.
 * [-table](#-table-fn-rest-lists) `(fn &rest lists)`
 * [-table-flat](#-table-flat-fn-rest-lists) `(fn &rest lists)`
 * [-first](#-first-pred-list) `(pred list)`
+* [-some](#-some-pred-list) `(pred list)`
 * [-last](#-last-pred-list) `(pred list)`
 * [-first-item](#-first-item-list) `(list)`
 * [-last-item](#-last-item-list) `(list)`
@@ -1407,6 +1408,18 @@ Alias: `-find`
 (-first 'even? '(1 2 3)) ;; => 2
 (-first 'even? '(1 3 5)) ;; => nil
 (--first (> it 2) '(1 2 3)) ;; => 3
+```
+
+#### -some `(pred list)`
+
+Return (`pred` x) for the first `list` item where (`pred` x) is non-nil, else nil.
+
+Alias: `-any`
+
+```el
+(-some 'even? '(1 2 3)) ;; => t
+(--some (member 'foo it) '((foo bar) (baz))) ;; => '(foo bar)
+(--some (plist-get it :bar) '((:foo 1 :bar 2) (:baz 3))) ;; => 2
 ```
 
 #### -last `(pred list)`

--- a/dash.el
+++ b/dash.el
@@ -391,6 +391,24 @@ Alias: `-find'"
 (defalias '-find '-first)
 (defalias '--find '--first)
 
+(defmacro --some (form list)
+  "Anaphoric form of `-some'."
+  (declare (debug (form form)))
+  (let ((n (make-symbol "needle")))
+    `(let (,n)
+       (--each-while ,list (not ,n)
+         (setq ,n ,form))
+       ,n)))
+
+(defun -some (pred list)
+  "Return (PRED x) for the first LIST item where (PRED x) is non-nil, else nil.
+
+Alias: `-any'"
+  (--some (funcall pred it) list))
+
+(defalias '-any '-some)
+(defalias '--any '--some)
+
 (defmacro --last (form list)
   "Anaphoric form of `-last'."
   (declare (debug (form form)))
@@ -1991,6 +2009,10 @@ structure such as plist or alist."
                              "--first"
                              "-find"
                              "--find"
+                             "-some"
+                             "--some"
+                             "-any"
+                             "--any"
                              "-last"
                              "--last"
                              "-first-item"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -546,6 +546,11 @@ new list."
     (-first 'even? '(1 3 5)) => nil
     (--first (> it 2) '(1 2 3)) => 3)
 
+  (defexamples -some
+    (-some 'even? '(1 2 3)) => t
+    (--some (member 'foo it) '((foo bar) (baz))) => '(foo bar)
+    (--some (plist-get it :bar) '((:foo 1 :bar 2) (:baz 3))) => 2)
+
   (defexamples -last
     (-last 'even? '(1 2 3 4 5 6 3 3 3)) => 6
     (-last 'even? '(1 3 7 5 9)) => nil


### PR DESCRIPTION
This is a port of the CL function `some` and the Scheme function `any`
from SRFI-1.  It is thought as addition to `-any?` (which returns a
boolean) and `-first` (which returns an element).  Unlike these it
returns the first truthy value of applying the predicate on each list
item.

Resolves #122.