### PR TITLE
docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ Include this in your emacs settings to get syntax highlighting:
 
 ## Functions
 
+All functions and constructs in the library are prefixed with a dash (-).
+
+There are also anaphoric versions of functions where that makes sense,
+prefixed with two dashes instead of one.
+
+While `-map` takes a function to map over the list, you can also use
+the anaphoric form with double dashes - which will then be executed
+with `it` exposed as the list item. Here's an example:
+
+```el
+(-map (lambda (n) (* n n)) '(1 2 3 4)) ;; normal version
+
+(--map (* it it) '(1 2 3 4)) ;; anaphoric version
+```
+
+of course the original can also be written like
+
+```el
+(defun square (n) (* n n))
+
+(-map 'square '(1 2 3 4))
+```
+
+which demonstrates the usefulness of both versions.
+
 
 ### Maps
 
@@ -256,31 +281,6 @@ These combinators require Emacs 24 for its lexical scope. So they are offered in
 * [-iteratefn](#-iteratefn-fn-n) `(fn n)`
 * [-fixfn](#-fixfn-fn-optional-equal-test-halt-test) `(fn &optional equal-test halt-test)`
 * [-prodfn](#-prodfn-rest-fns) `(&rest fns)`
-
-## Anaphoric functions
-
-There are also anaphoric versions of functions where that makes sense,
-prefixed with two dashes instead of one.
-
-While `-map` takes a function to map over the list, you can also use
-the anaphoric form with double dashes - which will then be executed
-with `it` exposed as the list item. Here's an example:
-
-```el
-(-map (lambda (n) (* n n)) '(1 2 3 4)) ;; normal version
-
-(--map (* it it) '(1 2 3 4)) ;; anaphoric version
-```
-
-of course the original can also be written like
-
-```el
-(defun square (n) (* n n))
-
-(-map 'square '(1 2 3 4))
-```
-
-which demonstrates the usefulness of both versions.
 
 
 ## Maps

--- a/dash-template.texi
+++ b/dash-template.texi
@@ -433,6 +433,12 @@ script for generating documentation.
 @item
 @uref{https://github.com/holomorph,Mark Oteiza} contributed the
 script to create an info manual.
+@item
+@uref{https://github.com/wasamasa,Vasilij Schneidermann} contributed
+@code{-some}.
+@item
+@uref{https://github.com/occidens,William West} made @code{-fixfn}
+more robust at handling floats.
 @end itemize
 
 Thanks!

--- a/dash.texi
+++ b/dash.texi
@@ -3580,6 +3580,12 @@ script for generating documentation.
 @item
 @uref{https://github.com/holomorph,Mark Oteiza} contributed the
 script to create an info manual.
+@item
+@uref{https://github.com/wasamasa,Vasilij Schneidermann} contributed
+@code{-some}.
+@item
+@uref{https://github.com/occidens,William West} made @code{-fixfn}
+more robust at handling floats.
 @end itemize
 
 Thanks!

--- a/readme-template.md
+++ b/readme-template.md
@@ -34,9 +34,7 @@ Include this in your emacs settings to get syntax highlighting:
 
 ## Functions
 
-[[ function-list ]]
-
-## Anaphoric functions
+All functions and constructs in the library are prefixed with a dash (-).
 
 There are also anaphoric versions of functions where that makes sense,
 prefixed with two dashes instead of one.
@@ -60,6 +58,8 @@ of course the original can also be written like
 ```
 
 which demonstrates the usefulness of both versions.
+
+[[ function-list ]]
 
 [[ function-docs ]]
 


### PR DESCRIPTION
Applied the change I did to the info manual in #120 to the README (moving the Anaphoric functions section into the Functions section), and did a merge from the README since it was there.

I didn't update `dash.info` because it was done with texinfo 4.8, and I have texinfo 5.2 which does things differently.  For instance, either the default fill is different (or it just makes different decisions about filling paragraphs), uses fancy quotation marks, and uses unicode `⇒' instead of `=>', and of course basically any change to the .texi results in the references in the .info all being different.

I can understand keeping README.md in the repo, since the github repo is the homepage for the project, but keeping generated things in the repo (the generated .texi and .info) should be the exception, not the rule.