### PR TITLE
Make it explicit that not all VALS are evalled in -if-let*

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1665,7 +1665,9 @@ See `-let' for the description of destructuring mechanism."
 VARS and do THEN, otherwise do ELSE. VARS-VALS should be a list
 of (VAR VAL) pairs.
 
-Note: binding is done according to `-let*'."
+Note: binding is done according to `-let*'. VALS are evalled
+sequentially, and evaluation stops after the first nil VAL is
+encountered."
   (declare (debug ((&rest (sexp form)) form body))
            (indent 2))
   (->> vars-vals
@@ -1698,7 +1700,9 @@ otherwise do ELSE."
 VARS and execute body. VARS-VALS should be a list of (VAR VAL)
 pairs.
 
-Note: binding is done according to `-let*'."
+Note: binding is done according to `-let*'. VALS are evalled
+sequentially, and evaluation stops after the first nil VAL is
+encountered."
   (declare (debug ((&rest (sexp form)) body))
            (indent 1))
   `(-if-let* ,vars-vals (progn ,@body)))


### PR DESCRIPTION
I was not initially sure whether something like

    (-when-let* ((a (subr-that-could-return-nil))
                 (b (blow-up-if-arg-is-nil a)))
      (message "All safe"))

would work properly. It does, so edit the docs (and that of `if-let*') to make it clear. Feel free to word it better of course (or to correct a misunderstanding of mine)

Initially mentioned in #142.