### PR TITLE
Add `-some->`, -some->>`, and `-some-->` macros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Functions pretending lists are trees.
 * [->](#--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [->>](#--x-form-rest-more) `(x form &rest more)`
 * [-->](#---x-form-rest-more) `(x form &rest more)`
+* [-some->](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
+* [-some->>](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
+* [-some-->](#-some---x-optional-form-rest-more) `(x &optional form &rest more)`
 
 ### Binding
 
@@ -1767,6 +1770,39 @@ in second form, etc.
 (--> "def" (concat "abc" it "ghi") upcase) ;; => "ABCDEFGHI"
 ```
 
+#### -some-> `(x &optional form &rest more)`
+
+When expr is non-nil, thread it through the first form (via [`->`](#--x-optional-form-rest-more)),
+and when that result is non-nil, through the next form, etc.
+
+```el
+(-some-> '(2 3 5)) ;; => '(2 3 5)
+(-some-> 5 square) ;; => 25
+(-some-> nil square) ;; => nil
+```
+
+#### -some->> `(x &optional form &rest more)`
+
+When expr is non-nil, thread it through the first form (via [`->>`](#--x-optional-form-rest-more)),
+and when that result is non-nil, through the next form, etc.
+
+```el
+(-some->> '(1 2 3) (-map 'square)) ;; => '(1 4 9)
+(-some->> '(1 3 5) (-last 'even?) (+ 100)) ;; => nil
+(-some->> '(2 4 6) (-last 'even?) (+ 100)) ;; => 106
+```
+
+#### -some--> `(x &optional form &rest more)`
+
+When expr in non-nil, thread it through the first form (via [`-->`](#---x-form-rest-more)),
+and when that result is non-nil, through the next form, etc.
+
+```el
+(-some--> "def" (concat "abc" it "ghi")) ;; => "abcdefghi"
+(-some--> nil (concat "abc" it "ghi")) ;; => nil
+(-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it)) ;; => nil
+```
+
 
 ## Binding
 
@@ -2436,6 +2472,7 @@ Change `readme-template.md` or `examples-to-docs.el` instead.
  - [Mark Oteiza](https://github.com/holomorph) contributed the script to create an info manual.
  - [Vasilij Schneidermann](https://github.com/wasamasa) contributed `-some`.
  - [William West](https://github.com/occidens) made `-fixfn` more robust at handling floats.
+ - [Cam Saül](https://github.com/cammsaul) contributed `-some->`, `-some->>`, and `-some-->`.
 
 Thanks!
 

--- a/dash.el
+++ b/dash.el
@@ -1191,6 +1191,33 @@ in second form, etc."
         (list form x))
     `(--> (--> ,x ,form) ,@more)))
 
+(defmacro -some-> (x &optional form &rest more)
+  "When expr is non-nil, thread it through the first form (via `->'),
+and when that result is non-nil, through the next form, etc."
+  (if (null form) x
+    (let ((result (make-symbol "result")))
+      `(-some-> (-when-let (,result ,x)
+                  (-> ,result ,form))
+                ,@more))))
+
+(defmacro -some->> (x &optional form &rest more)
+  "When expr is non-nil, thread it through the first form (via `->>'),
+and when that result is non-nil, through the next form, etc."
+  (if (null form) x
+    (let ((result (make-symbol "result")))
+      `(-some->> (-when-let (,result ,x)
+                   (->> ,result ,form))
+                 ,@more))))
+
+(defmacro -some--> (x &optional form &rest more)
+  "When expr in non-nil, thread it through the first form (via `-->'),
+and when that result is non-nil, through the next form, etc."
+  (if (null form) x
+    (let ((result (make-symbol "result")))
+      `(-some--> (-when-let (,result ,x)
+                   (--> ,result ,form))
+                 ,@more))))
+
 (defun -grade-up (comparator list)
   "Grade elements of LIST using COMPARATOR relation, yielding a
 permutation vector such that applying this permutation to LIST

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -733,7 +733,26 @@ new list."
   (defexamples -->
     (--> "def" (concat "abc" it "ghi")) => "abcdefghi"
     (--> "def" (concat "abc" it "ghi") (upcase it)) => "ABCDEFGHI"
-    (--> "def" (concat "abc" it "ghi") upcase) => "ABCDEFGHI"))
+    (--> "def" (concat "abc" it "ghi") upcase) => "ABCDEFGHI")
+
+  (defexamples -some->
+    (-some-> '(2 3 5)) => '(2 3 5)
+    (-some-> 5 square) => 25
+    (-some-> nil square) => nil
+    (-some-> 5 even? square) => nil)
+
+  (defexamples -some->>
+    (-some->> '(1 2 3) (-map 'square)) => '(1 4 9)
+    (-some->> '(1 3 5) (-last 'even?) (+ 100)) => nil
+    (-some->> '(2 4 6) (-last 'even?) (+ 100)) => 106
+    (-some->> '("A" "B" :c) (-filter 'stringp) (-reduce 'concat)) => "AB"
+    (-some->> '(:a :b :c) (-filter 'stringp) (-reduce 'concat)) => nil)
+
+  (defexamples -some-->
+    (-some--> "def" (concat "abc" it "ghi")) => "abcdefghi"
+    (-some--> nil (concat "abc" it "ghi")) => nil
+    (-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it)) => nil
+    (-some--> '(2 4 6) (-filter 'even? it) (append it it) (-map 'square it)) => '(4 16 36 4 16 36)))
 
 (def-example-group "Binding"
   "Convenient versions of `let` and `let*` constructs combined with flow control."


### PR DESCRIPTION
These are dash versions of the "nil-shortcutting" threading macros from Clojure, [some->](http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/some-%3E) and [some->>](http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/some-%3E%3E). Like `->`/`->>`/`-->`, but they only thread expressions through each successive form when they are non-nil.

```el
(->> 100
     (+ 20))
;; => 120

(->> nil
     (+ 20))
;; => Lisp error: (wrong-type-argument number-or-marker-p nil)

(-some->> nil
          (+ 20))
;; => nil
```