### PR TITLE
Speed-optimize '--each-while'.

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -75,16 +75,19 @@ special values."
   "Anaphoric form of `-each-while'."
   (declare (debug (form form body))
            (indent 2))
-  (let ((l (make-symbol "list"))
-        (c (make-symbol "continue")))
+  (let ((l (make-symbol "list")))
     `(let ((,l ,list)
-           (,c t)
-           (it-index 0))
-       (while (and ,l ,c)
-         (let ((it (car ,l)))
-           (if (not ,pred) (setq ,c nil) ,@body))
-         (setq it-index (1+ it-index))
-         (!cdr ,l)))))
+           (it-index 0)
+           it)
+       (while ,l
+         (setq it (car ,l))
+         (if ,pred
+             (progn
+               ,@body
+               (setq it-index (1+ it-index))
+               (!cdr ,l))
+           ;; Force loop break.
+           (setq ,l nil))))))
 
 (defun -each-while (list pred fn)
   "Call FN with every item in LIST while (PRED item) is non-nil.


### PR DESCRIPTION
I want to optimize several functions in the library. For a start, here is the first optimization. Tell me if it's OK to continue or if I shouldn't waste my time.

Reasoning: dash is low-level library used in many other places. It contains very generic functions that a purpose-agnostic and may or may not be used in performance-critical places. Implementation of the functions is also pretty simple, usually 1--10 lines. Therefore, I think, performance here is more important than code clarity.

This patch optimizes '--each-while':

* don't bind 'it' in a loop, it's slow: move it to encompassing 'let' instead;
* get rid of 'continue': we can just set 'list' to nil to break the loop early;
* rearrange loop body a bit so that there are fewer gotos in compiled code.

Benchmark:

    (defvar --large-list-- (--map-indexed it-index (-repeat 1000 nil)))
    (benchmark-run-compiled 10000
      (--each-while --large-list-- (< it 500)))
    (benchmark-run-compiled 10000
      (--each-while-optimized --large-list-- (< it 500)))

Before: 0.33+ seconds here, after: 0.28+ s here (runs differ a lot, I just repeat them several times and pick the best.