### PR TITLE
Add '-each-r' and '-each-r-while'.

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -93,6 +93,44 @@ Return nil, used for side-effects only."
 
 (put '-each-while 'lisp-indent-function 2)
 
+(defmacro --each-r (list &rest body)
+  "Anaphoric form of `-each-r'."
+  (declare (debug (form body))
+           (indent 1))
+  (let ((v (make-symbol "vector")))
+    `(let* ((,v (vconcat ,list))
+            (it-index (length ,v))
+            it)
+       (while (> it-index 0)
+         (setq it-index (1- it-index))
+         (setq it (aref ,v it-index))
+         ,@body))))
+
+(defun -each-r (list fn)
+  "Call FN with every item in LIST in reversed order.
+ Return nil, used for side-effects only."
+  (--each-r list (funcall fn it)))
+
+(defmacro --each-r-while (list pred &rest body)
+  "Anaphoric form of `-each-r-while'."
+  (declare (debug (form form body))
+           (indent 2))
+  (let ((v (make-symbol "vector")))
+    `(let* ((,v (vconcat ,list))
+            (it-index (length ,v))
+            it)
+       (while (> it-index 0)
+         (setq it-index (1- it-index))
+         (setq it (aref ,v it-index))
+         (if (not ,pred)
+             (setq it-index -1)
+           ,@body)))))
+
+(defun -each-r-while (list pred fn)
+  "Call FN with every item in reversed LIST while (PRED item) is non-nil.
+Return nil, used for side-effects only."
+  (--each-r-while list (funcall pred it) (funcall fn it)))
+
 (defmacro --dotimes (num &rest body)
   "Repeatedly executes BODY (presumably for side-effects) with `it` bound to integers from 0 through NUM-1."
   (declare (debug (form body))

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -962,6 +962,16 @@ new list."
     (let (s) (-each-while '(2 4 5 6) 'even? (lambda (item) (!cons item s))) s) => '(4 2)
     (let (s) (--each-while '(1 2 3 4) (< it 3) (!cons it s)) s) => '(2 1))
 
+  (defexamples -each-r
+    (let (s) (-each-r '(1 2 3) (lambda (item) (setq s (cons item s))))) => nil
+    (let (s) (-each-r '(1 2 3) (lambda (item) (setq s (cons item s)))) s) => '(1 2 3)
+    (let (s) (--each-r '(1 2 3) (setq s (cons it s))) s) => '(1 2 3)
+    (let (s) (--each-r (reverse (three-letters)) (setq s (cons it s))) s) => '("C" "B" "A"))
+
+  (defexamples -each-r-while
+    (let (s) (-each-r-while '(2 4 5 6) 'even? (lambda (item) (!cons item s))) s) => '(6)
+    (let (s) (--each-r-while '(1 2 3 4) (>= it 3) (!cons it s)) s) => '(3 4))
+
   (defexamples -dotimes
     (let (s) (-dotimes 3 (lambda (n) (!cons n s))) s) => '(2 1 0)
     (let (s) (--dotimes 5 (!cons it s)) s) => '(4 3 2 1 0)))


### PR DESCRIPTION
These are similar to `-each` and `-each-while` except they iterate list starting from the end. I have noticed that these would be useful at least for implementing (in a faster way) certain other `*-r` function in dash itself. Plus it's not that unheard of to want this functionality elsewhere.

* During iteration (using anaphoric macro, of course) `it-index` is bound to the values you'd expect: N - 1 ... 1, 0.

* List is not modified in any way, which is particularly important for the macro. E.g. this would give the expected result:

        (let ((l '("foo" "bar" "baz")))
          (--each-r l (message "there is string '%s' at position %d in list %s"
                               it it-index l)))

Implementation note: building vector is considerably faster than building a reversed list (vector takes less memory, so there is less GC), plus length comes naturally.