### PR TITLE
Fix check_copyright; Silence compiler-warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /dash.elc
+/dash-functional.elc
+/dash-autoloads.el
+/dash-pkg.el

--- a/dev/examples-to-docs.el
+++ b/dev/examples-to-docs.el
@@ -1,3 +1,26 @@
+;;; examples-to-docs.el --- Extract dash.el's doc from examples.el
+
+;; Copyright (C) 2015 Free Software Foundation, Inc.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; FIXME: Lots of duplication with examples-to-info.el.
+
+;;; Code:
+
 (require 'dash)
 (require 'dash-functional)
 (require 'help-fns)
@@ -110,7 +133,7 @@ FUNCTION may reference an elisp function, alias, macro or a subr."
                                                    (format "%S %S" command-name signature)))))
 
 (defun s-replace (old new s)
-  "Replaces OLD with NEW in S."
+  "Replace OLD with NEW in S."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
 (defun function-summary (function)
@@ -151,3 +174,5 @@ FUNCTION may reference an elisp function, alias, macro or a subr."
       (insert (mapconcat 'function-to-md functions "\n"))
 
       (simplify-quotes))))
+
+;;; examples-to-docs.el ends here

--- a/dev/examples-to-info.el
+++ b/dev/examples-to-info.el
@@ -1,3 +1,26 @@
+;;; examples-to-info.el --- Extract dash.el's Info from examples.el
+
+;; Copyright (C) 2015 Free Software Foundation, Inc.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; FIXME: Lots of duplication with examples-to-docs.el.
+
+;;; Code:
+
 (require 'dash)
 (require 'dash-functional)
 (require 'help-fns)
@@ -122,7 +145,7 @@ FUNCTION may reference an elisp function, alias, macro or a subr."
                                                    (format "%S %S" command-name signature)))))
 
 (defun s-replace (old new s)
-  "Replaces OLD with NEW in S."
+  "Replace OLD with NEW in S."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
 (defun function-summary (function)
@@ -176,3 +199,5 @@ FUNCTION may reference an elisp function, alias, macro or a subr."
       (insert (mapconcat 'function-to-info functions "\n"))
 
       (simplify-quotes))))
+
+;;; examples-to-info.el ends here

--- a/dev/examples-to-tests.el
+++ b/dev/examples-to-tests.el
@@ -1,3 +1,26 @@
+;;; examples-to-tests.el --- Extract dash.el's tests from examples.el
+
+;; Copyright (C) 2015 Free Software Foundation, Inc.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; FIXME: Lots of duplication with examples-to-info.el.
+
+;;; Code:
+
 (require 'ert)
 
 (defun example-to-should (actual sym expected)
@@ -8,7 +31,7 @@
         ((eq sym '!!>)
          `(should-error (eval ',actual) :type ',expected))
         (t
-         (error "invalid test case: %S" `(,actual ,sym ,expected)))))
+         (error "Invalid test case: %S" `(,actual ,sym ,expected)))))
 
 
 (defmacro defexamples (cmd &rest examples)
@@ -23,3 +46,4 @@
 (defun def-example-group (&rest _)) ; ignore
 
 (provide 'examples-to-tests)
+;;; examples-to-tests.el ends here

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -1,7 +1,26 @@
-;; -*- lexical-binding: t -*-
+;;; examples.el --- Examples/tests for dash.el's API  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2015 Free Software Foundation, Inc.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
 
 ;; Only the first three examples per function are shown in the docs,
 ;; so make those good.
+
+;;; Code:
 
 (require 'dash)
 
@@ -1093,3 +1112,5 @@ new list."
 ;; Local Variables:
 ;; eval: (font-lock-add-keywords nil '(("defexamples\\|def-example-group\\| => \\| !!> \\| ~>" (0 'font-lock-keyword-face)) ("(defexamples[[:blank:]]+\\(.*\\)" (1 'font-lock-function-name-face))))
 ;; End:
+
+;;; examples.el ends here


### PR DESCRIPTION
This is a variety of fixes from Stefan!


* .gitignore: Add files generated by "make" in elpa.git.

* dash.el (--map-first, --map-last): Silence compile warning when
`rep' does not make use of `it'.
(---partition-all-in-steps-reversed): Remove unused var `len'.
(dash--table-carry): Fix docstring and use DeMorgan.
(-find-indices): Remove unused var `i'.
(-compare-fn): Move before first use.

* dev/examples-to-tests.el:
* dev/examples-to-info.el:
* dev/examples-to-docs.el:
* dev/examples.el: Add copyright boilerplate.