### PR TITLE
Prefer make-list over --map.

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1078,8 +1078,7 @@ order.  The dimension of the result is (length lists).
 See also: `-table-flat'"
   (let ((restore-lists (copy-sequence lists))
         (last-list (last lists))
-        ;; FIXME: Why not just use (make-list (length lists) nil)?
-        (re (--map nil (number-sequence 1 (length lists)))))
+        (re (make-list (length lists) nil)))
     (while (car last-list)
       (let ((item (apply fn (-map 'car lists))))
         (push item (car re))


### PR DESCRIPTION
This is a small performance improvement using the `make-list'
primitive directly, rather than the more complex use of number-sequence
and --map.