### PR TITLE
Add -doto macro (like Clojure's doto)

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -71,6 +71,19 @@ special values."
          (setq it-index (1+ it-index))
          (!cdr ,l)))))
 
+(defmacro -doto (eval-initial-value &rest forms)
+  "Take a target form, then many forms to call with the target form in the
+second position. Returns the target form."
+  (declare (indent 1))
+  (let ((retval (gensym)))
+    `(let ((,retval ,eval-initial-value))
+       ,@(mapcar (lambda (form)
+                   (if (sequencep form)
+                       `(,(-first-item form) ,retval ,@(rest form))
+                     `(funcall form ,retval)))
+                 forms)
+       ,retval)))
+
 (defun -each (list fn)
   "Call FN with every item in LIST. Return nil, used for side-effects only."
   (--each list (funcall fn it)))

--- a/dash.el
+++ b/dash.el
@@ -79,7 +79,7 @@ argument. Returns the target form."
     `(let ((,retval ,eval-initial-value))
        ,@(mapcar (lambda (form)
                    (if (sequencep form)
-                       `(,(-first-item form) ,retval ,@(rest form))
+                       `(,(-first-item form) ,retval ,@(cdr form))
                      `(funcall form ,retval)))
                  forms)
        ,retval)))

--- a/dash.el
+++ b/dash.el
@@ -72,8 +72,10 @@ special values."
          (!cdr ,l)))))
 
 (defmacro -doto (eval-initial-value &rest forms)
-  "Take a target form, then many forms to call with the target form as the first
-argument. Returns the target form."
+  "Evals a form, then inserts that form as the 2nd argument to other forms.
+The EVAL-INITIAL-VALUE form is evaluated once. Its result is
+passed to FORMS, which are then evaluated sequentially. Returns
+the target form."
   (declare (indent 1))
   (let ((retval (make-symbol "value")))
     `(let ((,retval ,eval-initial-value))

--- a/dash.el
+++ b/dash.el
@@ -72,10 +72,10 @@ special values."
          (!cdr ,l)))))
 
 (defmacro -doto (eval-initial-value &rest forms)
-  "Take a target form, then many forms to call with the target form in the
-second position. Returns the target form."
+  "Take a target form, then many forms to call with the target form as the first
+argument. Returns the target form."
   (declare (indent 1))
-  (let ((retval (gensym)))
+  (let ((retval (make-symbol "value")))
     `(let ((,retval ,eval-initial-value))
        ,@(mapcar (lambda (form)
                    (if (sequencep form)

--- a/dash.el
+++ b/dash.el
@@ -72,7 +72,7 @@ special values."
          (!cdr ,l)))))
 
 (defmacro -doto (eval-initial-value &rest forms)
-  "Evals a form, then inserts that form as the 2nd argument to other forms.
+  "Eval a form, then insert that form as the 2nd argument to other forms.
 The EVAL-INITIAL-VALUE form is evaluated once. Its result is
 passed to FORMS, which are then evaluated sequentially. Returns
 the target form."

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -998,7 +998,10 @@ new list."
 
   (defexamples -dotimes
     (let (s) (-dotimes 3 (lambda (n) (!cons n s))) s) => '(2 1 0)
-    (let (s) (--dotimes 5 (!cons it s)) s) => '(4 3 2 1 0)))
+    (let (s) (--dotimes 5 (!cons it s)) s) => '(4 3 2 1 0))
+
+  (defexamples -doto
+    (-doto '(1 2 3) (!cdr) (!cdr)) => '(3)))
 
 (def-example-group "Destructive operations" nil
   (defexamples !cons

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -1001,7 +1001,8 @@ new list."
     (let (s) (--dotimes 5 (!cons it s)) s) => '(4 3 2 1 0))
 
   (defexamples -doto
-    (-doto '(1 2 3) (!cdr) (!cdr)) => '(3)))
+    (-doto '(1 2 3) (!cdr) (!cdr)) => '(3)
+    (-doto '(1 . 2) (setcar 3) (setcdr 4)) => '(3 . 4)))
 
 (def-example-group "Destructive operations" nil
   (defexamples !cons


### PR DESCRIPTION
Here is its documentation in clojuredocs:

```
  (doto x & forms)

  Evaluates x then calls all of the methods and functions with the
  value of x supplied at the front of the given arguments.  The forms
  are evaluated in order.  Returns x.
  (doto (new java.util.HashMap) (.put "a" 1) (.put "b" 2))
```
Documentation:
https://clojuredocs.org/clojure.core/doto

Source (clojure):
https://github.com/clojure/clojure/blob/clojure-1.7.0/src/clj/clojure/core.clj#L3700