### PR TITLE
Add `-each-indexed` and an anaphoric equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Functions iterating over lists for side-effect only.
 
 * [-each](#-each-list-fn) `(list fn)`
 * [-each-while](#-each-while-list-pred-fn) `(list pred fn)`
+* [-each-indexed](#-each-indexed-list-fn) `(list fn)`
 * [-dotimes](#-dotimes-num-fn) `(num fn)`
 
 ### Destructive operations
@@ -365,6 +366,8 @@ See also: [`-map-when`](#-map-when-pred-rep-list), [`-replace-last`](#-replace-l
 Return a new list consisting of the result of (`fn` index item) for each item in `list`.
 
 In the anaphoric form `--map-indexed`, the index is exposed as `it-index`.
+
+See also: [`-each-indexed`](#-each-indexed-list-fn).
 
 ```el
 (-map-indexed (lambda (index item) (- item index)) '(1 2 3 4)) ;; => '(1 1 1 1)
@@ -2135,6 +2138,19 @@ Return nil, used for side-effects only.
 ```el
 (let (s) (-each-while '(2 4 5 6) 'even? (lambda (item) (!cons item s))) s) ;; => '(4 2)
 (let (s) (--each-while '(1 2 3 4) (< it 3) (!cons it s)) s) ;; => '(2 1)
+```
+
+#### -each-indexed `(list fn)`
+
+Call (`fn` index item) for each item in `list`.
+
+In the anaphoric form `--each-indexed`, the index is exposed as `it-index`.
+
+See also: [`-map-indexed`](#-map-indexed-fn-list).
+
+```el
+(let (s) (-each-indexed '(a b c) (lambda (index item) (setq s (cons (list item index) s)))) s) ;; => '((c 2) (b 1) (a 0))
+(let (s) (--each-indexed '(a b c) (setq s (cons (list it it-index) s))) s) ;; => '((c 2) (b 1) (a 0))
 ```
 
 #### -dotimes `(num fn)`

--- a/dash.el
+++ b/dash.el
@@ -77,6 +77,16 @@ special values."
 
 (put '-each 'lisp-indent-function 1)
 
+(defalias '--each-indexed '--each)
+
+(defun -each-indexed (list fn)
+  "Call (FN index item) for each item in LIST.
+
+In the anaphoric form `--each-indexed', the index is exposed as `it-index`.
+
+See also: `-map-indexed'."
+  (--each list (funcall fn it-index it)))
+
 (defmacro --each-while (list pred &rest body)
   "Anaphoric form of `-each-while'."
   (declare (debug (form form body))
@@ -317,7 +327,9 @@ If you want to select the original items satisfying a predicate use `-filter'."
 (defun -map-indexed (fn list)
   "Return a new list consisting of the result of (FN index item) for each item in LIST.
 
-In the anaphoric form `--map-indexed', the index is exposed as `it-index`."
+In the anaphoric form `--map-indexed', the index is exposed as `it-index`.
+
+See also: `-each-indexed'."
   (--map-indexed (funcall fn it-index it) list))
 
 (defmacro --map-when (pred rep list)

--- a/dash.texi
+++ b/dash.texi
@@ -300,6 +300,8 @@ Return a new list consisting of the result of (@var{fn} index item) for each ite
 
 In the anaphoric form @code{--map-indexed}, the index is exposed as `it-index`.
 
+See also: @code{-each-indexed} (@pxref{-each-indexed}).
+
 @example
 @group
 (-map-indexed (lambda (index item) (- item index)) '(1 2 3 4))
@@ -3177,6 +3179,26 @@ Return nil, used for side-effects only.
 @group
 (let (s) (--each-while '(1 2 3 4) (< it 3) (!cons it s)) s)
     @result{} '(2 1)
+@end group
+@end example
+@end defun
+
+@anchor{-each-indexed}
+@defun -each-indexed (list fn)
+Call (@var{fn} index item) for each item in @var{list}.
+
+In the anaphoric form @code{--each-indexed}, the index is exposed as `it-index`.
+
+See also: @code{-map-indexed} (@pxref{-map-indexed}).
+
+@example
+@group
+(let (s) (-each-indexed '(a b c) (lambda (index item) (setq s (cons (list item index) s)))) s)
+    @result{} '((c 2) (b 1) (a 0))
+@end group
+@group
+(let (s) (--each-indexed '(a b c) (setq s (cons (list it it-index) s))) s)
+    @result{} '((c 2) (b 1) (a 0))
 @end group
 @end example
 @end defun

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -996,6 +996,10 @@ new list."
     (let (s) (-each-while '(2 4 5 6) 'even? (lambda (item) (!cons item s))) s) => '(4 2)
     (let (s) (--each-while '(1 2 3 4) (< it 3) (!cons it s)) s) => '(2 1))
 
+  (defexamples -each-indexed
+    (let (s) (-each-indexed '(a b c) (lambda (index item) (setq s (cons (list item index) s)))) s) => '((c 2) (b 1) (a 0))
+    (let (s) (--each-indexed '(a b c) (setq s (cons (list it it-index) s))) s) => '((c 2) (b 1) (a 0)))
+
   (defexamples -dotimes
     (let (s) (-dotimes 3 (lambda (n) (!cons n s))) s) => '(2 1 0)
     (let (s) (--dotimes 5 (!cons it s)) s) => '(4 3 2 1 0)))


### PR DESCRIPTION
This adds `-each-indexed` and an anaphoric variant `--each-indexed`,
equivalent to `-map-indexed`.

Whilst `--each` already defines `it-index`, it's not documented. Having
a separate version is more explicit and more discoverable because it's
similarly named to `-map-indexed`.

Fixes #175.
