### PR TITLE
Edebug support for threading macros

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1260,6 +1260,7 @@ See also: `-select-columns', `-select-by-indices'"
 in the first form, making a list of it if it is not a list
 already. If there are more forms, insert the first form as the
 second item in second form, etc."
+  (declare (debug (form &rest [&or symbolp (sexp &rest form)])))
   (cond
    ((null form) x)
    ((null more) (if (listp form)
@@ -1272,6 +1273,7 @@ second item in second form, etc."
 in the first form, making a list of it if it is not a list
 already. If there are more forms, insert the first form as the
 last item in second form, etc."
+  (declare (debug ->))
   (cond
    ((null form) x)
    ((null more) (if (listp form)
@@ -1284,6 +1286,7 @@ last item in second form, etc."
 signified by the token `it' in the first form. If there are more
 forms, insert the first form at the position signified by `it' in
 in second form, etc."
+  (declare (debug ->))
   (if (null more)
       (if (listp form)
           (--map-when (eq it 'it) x form)
@@ -1293,6 +1296,7 @@ in second form, etc."
 (defmacro -some-> (x &optional form &rest more)
   "When expr is non-nil, thread it through the first form (via `->'),
 and when that result is non-nil, through the next form, etc."
+  (declare (debug ->))
   (if (null form) x
     (let ((result (make-symbol "result")))
       `(-some-> (-when-let (,result ,x)
@@ -1302,6 +1306,7 @@ and when that result is non-nil, through the next form, etc."
 (defmacro -some->> (x &optional form &rest more)
   "When expr is non-nil, thread it through the first form (via `->>'),
 and when that result is non-nil, through the next form, etc."
+  (declare (debug ->))
   (if (null form) x
     (let ((result (make-symbol "result")))
       `(-some->> (-when-let (,result ,x)
@@ -1311,6 +1316,7 @@ and when that result is non-nil, through the next form, etc."
 (defmacro -some--> (x &optional form &rest more)
   "When expr in non-nil, thread it through the first form (via `-->'),
 and when that result is non-nil, through the next form, etc."
+  (declare (debug ->))
   (if (null form) x
     (let ((result (make-symbol "result")))
       `(-some--> (-when-let (,result ,x)


### PR DESCRIPTION
Given an elisp expression of the form:

    (->> (+ 1 1)
         (+ 2)
         (* 3)
         (format "%s"))

This tells edebug that the first argument is an expression, so users can
step through it. This is an improvement over the current situation,
where users cannot step through any part of a threaded expression.

I've also changed the indentation, so threading macros are indented
similarly to other scoping macros:

    (->> (+ 1 1)
      (+ 2)
      (* 3)
      (format "%s"))

Note that this indentation and debugging behaviour matches thread-first
in Emacs 25:
http://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/emacs-lisp/subr-x.el?id=emacs-25.0.95#n49