### PR TITLE
Fix setf on emacs23

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -578,14 +578,26 @@ Alias: `-any'"
 
 \(fn LIST)")
 
-(gv-define-simple-setter -first-item setcar)
+;; TODO: emacs23 support, when dropped remove the condition
+(eval-when-compile
+  (require 'cl)
+  (if (fboundp 'gv-define-simple-setter)
+      (gv-define-simple-setter -first-item setcar)
+    (require 'cl)
+    (with-no-warnings
+      (defsetf -first-item (x) (val) `(setcar ,x ,val)))))
 
 (defun -last-item (list)
   "Return the last item of LIST, or nil on an empty list."
   (declare (pure t) (side-effect-free t))
   (car (last list)))
 
-(gv-define-setter -last-item (val x) `(setcar (last ,x) ,val))
+;; TODO: emacs23 support, when dropped remove the condition
+(eval-when-compile
+  (if (fboundp 'gv-define-setter)
+      (gv-define-setter -last-item (val x) `(setcar (last ,x) ,val))
+    (with-no-warnings
+      (defsetf -last-item (x) (val) `(setcar (last ,x) ,val)))))
 
 (defun -butlast (list)
   "Return a list of all items in list except for the last."


### PR DESCRIPTION
`gv-define-simple-setter` is not defined on Emacs 23, so we need to use
the macro `defsetf` instead. `defsetf` is not autoloaded, so we must
require 'cl before using it.

However, the whole form is macro-expanded on all Emacs versions, so
writing:

```emacs-lisp
(eval-when-compile
  (if (fboundp 'gv-define-simple-setter)
      (gv-define-simple-setter -first-item setcar)
    (require 'cl)
    (defsetf -first-item (x) (val) `(setcar ,x ,val))))
```

produces byte-compile errors on Emacs 24+. The byte compiler there is
assuming that `(defsetf ...)` is a function call because it hasn't
executed the `(require 'cl)`.

We solve this by wrapping in another level of `eval-when-compile`. I
think this is roughly equivalent to meta levels:
http://www.phyast.pitt.edu/~micheles/scheme/scheme22.html
