### PR TITLE
Correct use of eval-after-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To get function combinators:
 Font lock of dash functions in emacs lisp buffers is now optional.
 Include this in your emacs settings to get syntax highlighting:
 
-    (eval-after-load "dash" '(dash-enable-font-lock))
+    (eval-after-load 'dash '(dash-enable-font-lock))
 
 ## Functions
 

--- a/dash-template.texi
+++ b/dash-template.texi
@@ -125,7 +125,7 @@ Font lock of dash functions in emacs lisp buffers is now optional.
 Include this in your emacs settings to get syntax highlighting:
 
 @lisp
-(eval-after-load "dash" '(dash-enable-font-lock))
+(eval-after-load 'dash '(dash-enable-font-lock))
 @end lisp
 
 @node Functions

--- a/dash.el
+++ b/dash.el
@@ -2353,7 +2353,7 @@ structure such as plist or alist."
 
 (defun dash-enable-font-lock ()
   "Add syntax highlighting to dash functions, macros and magic values."
-  (eval-after-load "lisp-mode"
+  (eval-after-load 'lisp-mode
     '(progn
        (let ((new-keywords '(
                              "-each"

--- a/dash.info
+++ b/dash.info
@@ -131,7 +131,7 @@ File: dash.info,  Node: Syntax highlighting of dash functions,  Prev: Using in a
 Font lock of dash functions in emacs lisp buffers is now optional.
 Include this in your emacs settings to get syntax highlighting:
 
-     (eval-after-load "dash" '(dash-enable-font-lock))
+     (eval-after-load 'dash '(dash-enable-font-lock))
 
 
 File: dash.info,  Node: Functions,  Next: Development,  Prev: Installation,  Up: Top

--- a/dash.texi
+++ b/dash.texi
@@ -140,7 +140,7 @@ Font lock of dash functions in emacs lisp buffers is now optional.
 Include this in your emacs settings to get syntax highlighting:
 
 @lisp
-(eval-after-load "dash" '(dash-enable-font-lock))
+(eval-after-load 'dash '(dash-enable-font-lock))
 @end lisp
 
 @node Functions

--- a/readme-template.md
+++ b/readme-template.md
@@ -37,7 +37,7 @@ To get function combinators:
 Font lock of dash functions in emacs lisp buffers is now optional.
 Include this in your emacs settings to get syntax highlighting:
 
-    (eval-after-load "dash" '(dash-enable-font-lock))
+    (eval-after-load 'dash '(dash-enable-font-lock))
 
 ## Functions
 


### PR DESCRIPTION
With a symbol, only the file providing the feature triggers the
eval-after-load. With a string, any file named the same way triggers
it. This is problematic for custom configurations named after
packages.