### PR TITLE
Ensure that -first-item is as fast as car

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -578,6 +578,11 @@ Alias: `-any'"
 
 \(fn LIST)")
 
+;; Ensure that calls to `-first-item' are compiled to a single opcode,
+;; just like `car'.
+(put '-first-item 'byte-opcode 'byte-car)
+(put '-first-item 'byte-compile 'byte-compile-one-arg)
+
 ;; TODO: emacs23 support, when dropped remove the condition
 (eval-when-compile
   (require 'cl)


### PR DESCRIPTION
Add symbol properties to -first-item so the byte-compiler compiles
calls to the car opcode. This ensures that -first-item has the same
performance as car.

Add symbol properties to -first-item so the byte-compiler compiles
calls to the car opcode. This ensures that -first-item has the same
performance as car.

For example, given the following function:

    (defun wh/call-first-item (x)
      (-first-item x))

This would compile to:

    byte code for wh/call-first-item:
      args: (arg1)
    0	constant  -first-item
    1	stack-ref 1
    2	call	  1
    3	return

Whereas it now compiles to:

    byte code for wh/call-first-item:
      args: (arg1)
    0       dup
    1       car
    2       return