### PR TITLE
Make --> bind IT for use anywhere in FORMS, and add -as->.

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -803,7 +803,23 @@ new list."
     (--> "def" (concat "abc" it "ghi") (upcase it)) => "ABCDEFGHI"
     (--> "def" (concat "abc" it "ghi") upcase) => "ABCDEFGHI"
     (--> "def" upcase) => "DEF"
-    (--> 3 (car (list it))) => 3)
+    (--> 3 (car (list it))) => 3
+
+    (--> '(1 2 3 4) (--map (1+ it) it)) => '(2 3 4 5)
+    (--map (--> it (1+ it)) '(1 2 3 4)) => '(2 3 4 5)
+
+    (--filter (--> it (equal 0 (mod it 2))) '(1 2 3 4)) => '(2 4)
+    (--> '(1 2 3 4) (--filter (equal 0 (mod it 2)) it)) => '(2 4)
+
+    (--annotate (--> it (< 1 it)) '(0 1 2 3)) => '((nil . 0)
+                                                   (nil . 1)
+                                                   (t . 2)
+                                                   (t . 3))
+
+    (--> '(0 1 2 3) (--annotate (< 1 it) it)) => '((nil . 0)
+                                                   (nil . 1)
+                                                   (t . 2)
+                                                   (t . 3)))
 
   (defexamples -as->
     (-as-> 3 my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) my-var)) => '(8)

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -801,7 +801,17 @@ new list."
   (defexamples -->
     (--> "def" (concat "abc" it "ghi")) => "abcdefghi"
     (--> "def" (concat "abc" it "ghi") (upcase it)) => "ABCDEFGHI"
-    (--> "def" (concat "abc" it "ghi") upcase) => "ABCDEFGHI")
+    (--> "def" (concat "abc" it "ghi") upcase) => "ABCDEFGHI"
+    (--> "def" upcase) => "DEF"
+    (--> 3 (car (list it))) => 3)
+
+  (defexamples -as->
+    (-as-> 3 my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) my-var)) => '(8)
+    (-as-> 3 my-var 1+) => 4
+    (-as-> 3 my-var) => 3
+    (-as-> "def" string (concat "abc" string "ghi")) => "abcdefghi"
+    (-as-> "def" string (concat "abc" string "ghi") upcase) => "ABCDEFGHI"
+    (-as-> "def" string (concat "abc" string "ghi") (upcase string)) => "ABCDEFGHI")
 
   (defexamples -some->
     (-some-> '(2 3 5)) => '(2 3 5)


### PR DESCRIPTION
This code fixes #218, in a way that I think is fairly straightforward, and not error-prone. I've added a example to show the problem that was fixed. 

It keeps the feature that if a FORM is a symbol, the code will treat that symbol as a function, and pass it the single arg `it`. I keep this only because it's a legacy feature; it's [not how Clojure operates](https://repl.it/IGM4/1), and was surprising to me. But, as mentioned, I kept it.

This also fixes a multiple-evaluation bug; if `it` appears multiple times in a FORM, the value will be evaluated multiple times. The following code prompts for input twice with the old `-->`, but only once with this version.

`(--> (progn (read-from-minibuffer "How many prompts? ") 3) (+ it it))`

As a helper method, this adds a new method `-as->`, which is a version of `-->` that takes the variable explicitly, as opposed to `-->` only using `it`. I think the standard dash.el nomenclature would be to name the anaphoric version with an extra dash, but the anaphoric version is `-->`, and the version with one fewer dash (`->`) is already used. Please let me know if there's a better name for this new function. The existing name is a riff on Clojure's, but beginning with a dash to fit in with names here.

I'm happy to make changes, whether to the name, or anything else here.