### PR TITLE
Add new methods to partition a list each time elements occur, or a predicate is true, but include those elements in the list.

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1032,6 +1032,36 @@ returns the header value, but only after seeing at least one
 other value (the body)."
   (--partition-by-header (funcall fn it) list))
 
+(defun -partition-after-pred (pred list)
+  "Partition directly after each time PRED is true on an element of LIST."
+  (when list
+    (let ((rest (-partition-after-pred pred
+                                       (cdr list))))
+      (if (funcall pred (car list))
+          ;;split after (car list)
+          (cons (list (car list))
+                rest)
+
+        ;;don't split after (car list)
+        (cons (cons (car list)
+                    (car rest))
+              (cdr rest))))))
+
+(defun -partition-before-pred (pred list)
+  "Partition directly before each time PRED is true on an element of LIST."
+  (nreverse (-map #'reverse
+                  (-partition-after-pred pred (reverse list)))))
+
+(defun -partition-after-item (item list)
+  "Partition directly after each time ITEM appears in LIST."
+  (-partition-after-pred (lambda (ele) (equal ele item))
+                         list))
+
+(defun -partition-before-item (item list)
+  "Partition directly before each time ITEM appears in LIST."
+  (-partition-before-pred (lambda (ele) (equal ele item))
+                          list))
+
 (defmacro --group-by (form list)
   "Anaphoric form of `-group-by'."
   (declare (debug t))

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -506,6 +506,37 @@ new list."
     (--partition-by-header (> it 0) '(1 2 0 1 0 1 2 3 0)) => '((1 2 0) (1 0) (1 2 3 0))
     (-partition-by-header 'even? '(2 1 1 1 4 1 3 5 6 6 1)) => '((2 1 1 1) (4 1 3 5) (6 6 1)))
 
+  (defexamples -partition-after-pred
+    (-partition-after-pred #'oddp '()) => '()
+    (-partition-after-pred #'oddp '(1)) => '((1))
+    (-partition-after-pred #'oddp '(0 1)) => '((0 1))
+    (-partition-after-pred #'oddp '(1 1)) => '((1) (1))
+    (-partition-after-pred #'oddp '(0 0 0 1 0 1 1 0 1)) => '((0 0 0 1) (0 1) (1) (0 1)))
+
+  (defexamples -partition-before-pred
+    (-partition-before-pred #'oddp '()) => '()
+    (-partition-before-pred #'oddp '(1)) => '((1))
+    (-partition-before-pred #'oddp '(0 1)) => '((0) (1))
+    (-partition-before-pred #'oddp '(1 1)) => '((1) (1))
+    (-partition-before-pred #'oddp '(0 1 0)) => '((0) (1 0))
+    (-partition-before-pred #'oddp '(0 0 0 1 0 1 1 0 1)) => '((0 0 0) (1 0) (1) (1 0) (1)))
+
+  (defexamples -partition-before-item
+    (-partition-before-item 3 '()) => '()
+    (-partition-before-item 3 '(1)) => '((1))
+    (-partition-before-item 3 '(3)) => '((3))
+    (-partition-before-item 3 '(1 3)) => '((1) (3))
+    (-partition-before-item 3 '(1 3 4)) => '((1) (3 4))
+    (-partition-before-item 3 '(1 2 3 2 3 3 4)) => '((1 2) (3 2) (3) (3 4)))
+
+  (defexamples -partition-after-item
+    (-partition-after-item 3 '()) => '()
+    (-partition-after-item 3 '(1)) => '((1))
+    (-partition-after-item 3 '(3)) => '((3))
+    (-partition-after-item 3 '(3 1)) => '((3) (1))
+    (-partition-after-item 3 '(3 1 3)) => '((3) (1 3))
+    (-partition-after-item 3 '(3 2 3 3 4 5 3 2)) => '((3) (2 3) (3) (4 5 3) (2)))
+
   (defexamples -group-by
     (-group-by 'even? '()) => '()
     (-group-by 'even? '(1 1 2 2 2 3 4 6 8)) => '((nil . (1 1 3)) (t . (2 2 2 4 6 8)))


### PR DESCRIPTION
These methods partition a list each time a predicate is true, or an item is found. These are similar to `-split-on` and `-split-when`, but include the item that necessitates the split. These are also similar to `-partition-by` and other similar partition functions. Examples/tests are included.

The new methods are -partition-before-pred, -partition-after-pred, -partition-before-item, and -partition-after-item. I didn't name them with `-on` (for items) or `-when` (for predicates) because I couldn't find a way to include that in the name and also include `-before` and `-after` without sounding awkward. I'm happy to do a rename if you have ideas for better names.