### PR TITLE
Add 'see also' for -select and -remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Return a new list of the items in `list` for which `pred` returns a non-nil valu
 
 Alias: `-select`
 
-See also: [`-keep`](#-keep-fn-list)
+See also: [`-keep`](#-keep-fn-list), [`-remove`](#-remove-pred-list).
 
 ```el
 (-filter (lambda (num) (= 0 (% num 2))) '(1 2 3 4)) ;; => '(2 4)
@@ -473,6 +473,8 @@ See also: [`-keep`](#-keep-fn-list)
 Return a new list of the items in `list` for which `pred` returns nil.
 
 Alias: `-reject`
+
+See also: [`-filter`](#-filter-pred-list).
 
 ```el
 (-remove (lambda (num) (= 0 (% num 2))) '(1 2 3 4)) ;; => '(1 3)

--- a/dash.el
+++ b/dash.el
@@ -236,7 +236,9 @@ See also: `-reduce-r-from', `-reduce'"
   `(-reduce-r (lambda (&optional it acc) ,form) ,list))
 
 (defmacro --filter (form list)
-  "Anaphoric form of `-filter'."
+  "Anaphoric form of `-filter'.
+
+See also: `--remove'."
   (declare (debug (form form)))
   (let ((r (make-symbol "result")))
     `(let (,r)
@@ -248,21 +250,25 @@ See also: `-reduce-r-from', `-reduce'"
 
 Alias: `-select'
 
-See also: `-keep'"
+See also: `-keep', `-remove'."
   (--filter (funcall pred it) list))
 
 (defalias '-select '-filter)
 (defalias '--select '--filter)
 
 (defmacro --remove (form list)
-  "Anaphoric form of `-remove'."
+  "Anaphoric form of `-remove'.
+
+See also `--filter'."
   (declare (debug (form form)))
   `(--filter (not ,form) ,list))
 
 (defun -remove (pred list)
   "Return a new list of the items in LIST for which PRED returns nil.
 
-Alias: `-reject'"
+Alias: `-reject'
+
+See also: `-filter'."
   (--remove (funcall pred it) list))
 
 (defalias '-reject '-remove)

--- a/dash.info
+++ b/dash.info
@@ -341,7 +341,7 @@ Functions returning a sublist of the original list.
 
      Alias: ‘-select’
 
-     See also: ‘-keep’ (*note -keep::)
+     See also: ‘-keep’ (*note -keep::), ‘-remove’ (*note -remove::).
 
           (-filter (lambda (num) (= 0 (% num 2))) '(1 2 3 4))
               ⇒ '(2 4)
@@ -355,6 +355,8 @@ Functions returning a sublist of the original list.
      nil.
 
      Alias: ‘-reject’
+
+     See also: ‘-filter’ (*note -filter::).
 
           (-remove (lambda (num) (= 0 (% num 2))) '(1 2 3 4))
               ⇒ '(1 3)
@@ -2732,9 +2734,9 @@ Index
 * -distinct:                             Set operations.    (line  62)
 * -dotimes:                              Side-effects.      (line  41)
 * -doto:                                 Side-effects.      (line  50)
-* -drop:                                 Sublist selection. (line 123)
-* -drop-last:                            Sublist selection. (line 135)
-* -drop-while:                           Sublist selection. (line 156)
+* -drop:                                 Sublist selection. (line 125)
+* -drop-last:                            Sublist selection. (line 137)
+* -drop-while:                           Sublist selection. (line 158)
 * -each:                                 Side-effects.      (line   8)
 * -each-indexed:                         Side-effects.      (line  28)
 * -each-while:                           Side-effects.      (line  19)
@@ -2795,7 +2797,7 @@ Index
 * -max-by:                               Reductions.        (line 151)
 * -min:                                  Reductions.        (line 117)
 * -min-by:                               Reductions.        (line 127)
-* -non-nil:                              Sublist selection. (line  78)
+* -non-nil:                              Sublist selection. (line  80)
 * -none?:                                Predicates.        (line  30)
 * -not:                                  Function combinators.
                                                             (line 119)
@@ -2830,9 +2832,9 @@ Index
 * -remove:                               Sublist selection. (line  23)
 * -remove-at:                            List to list.      (line 146)
 * -remove-at-indices:                    List to list.      (line 159)
-* -remove-first:                         Sublist selection. (line  36)
-* -remove-item:                          Sublist selection. (line  66)
-* -remove-last:                          Sublist selection. (line  51)
+* -remove-first:                         Sublist selection. (line  38)
+* -remove-item:                          Sublist selection. (line  68)
+* -remove-last:                          Sublist selection. (line  53)
 * -repeat:                               Other list operations.
                                                             (line  17)
 * -replace:                              List to list.      (line  67)
@@ -2844,11 +2846,11 @@ Index
 * -rpartial:                             Function combinators.
                                                             (line  20)
 * -same-items?:                          Predicates.        (line  72)
-* -select-by-indices:                    Sublist selection. (line 167)
-* -select-column:                        Sublist selection. (line 197)
-* -select-columns:                       Sublist selection. (line 178)
+* -select-by-indices:                    Sublist selection. (line 169)
+* -select-column:                        Sublist selection. (line 199)
+* -select-columns:                       Sublist selection. (line 180)
 * -separate:                             Partitioning.      (line  63)
-* -slice:                                Sublist selection. (line  84)
+* -slice:                                Sublist selection. (line  86)
 * -snoc:                                 Other list operations.
                                                             (line  42)
 * -some:                                 Other list operations.
@@ -2869,9 +2871,9 @@ Index
                                                             (line 161)
 * -table-flat:                           Other list operations.
                                                             (line 180)
-* -take:                                 Sublist selection. (line 100)
-* -take-last:                            Sublist selection. (line 111)
-* -take-while:                           Sublist selection. (line 145)
+* -take:                                 Sublist selection. (line 102)
+* -take-last:                            Sublist selection. (line 113)
+* -take-while:                           Sublist selection. (line 147)
 * -tree-map:                             Tree operations.   (line  28)
 * -tree-map-nodes:                       Tree operations.   (line  39)
 * -tree-mapreduce:                       Tree operations.   (line  85)
@@ -2914,170 +2916,170 @@ Ref: -mapcat9342
 Ref: -copy9718
 Node: Sublist selection9922
 Ref: -filter10115
-Ref: -remove10533
-Ref: -remove-first10895
-Ref: -remove-last11422
-Ref: -remove-item11943
-Ref: -non-nil12337
-Ref: -slice12496
-Ref: -take13028
-Ref: -take-last13336
-Ref: -drop13659
-Ref: -drop-last13932
-Ref: -take-while14192
-Ref: -drop-while14542
-Ref: -select-by-indices14898
-Ref: -select-columns15412
-Ref: -select-column16117
-Node: List to list16580
-Ref: -keep16772
-Ref: -concat17275
-Ref: -flatten17572
-Ref: -flatten-n18331
-Ref: -replace18718
-Ref: -replace-first19181
-Ref: -replace-last19677
-Ref: -insert-at20166
-Ref: -replace-at20493
-Ref: -update-at20888
-Ref: -remove-at21379
-Ref: -remove-at-indices21867
-Node: Reductions22449
-Ref: -reduce-from22618
-Ref: -reduce-r-from23404
-Ref: -reduce24189
-Ref: -reduce-r24997
-Ref: -count25913
-Ref: -sum26137
-Ref: -product26326
-Ref: -min26535
-Ref: -min-by26761
-Ref: -max27284
-Ref: -max-by27509
-Node: Unfolding28037
-Ref: -iterate28276
-Ref: -unfold28721
-Node: Predicates29529
-Ref: -any?29653
-Ref: -all?29973
-Ref: -none?30303
-Ref: -only-some?30605
-Ref: -contains?31090
-Ref: -same-items?31479
-Ref: -is-prefix?31864
-Ref: -is-suffix?32187
-Ref: -is-infix?32510
-Node: Partitioning32864
-Ref: -split-at33052
-Ref: -split-with33337
-Ref: -split-on33740
-Ref: -split-when34416
-Ref: -separate35056
-Ref: -partition35498
-Ref: -partition-all35950
-Ref: -partition-in-steps36378
-Ref: -partition-all-in-steps36875
-Ref: -partition-by37360
-Ref: -partition-by-header37742
-Ref: -partition-after-pred38346
-Ref: -partition-before-pred38717
-Ref: -partition-before-item39095
-Ref: -partition-after-item39406
-Ref: -group-by39712
-Node: Indexing40149
-Ref: -elem-index40351
-Ref: -elem-indices40746
-Ref: -find-index41129
-Ref: -find-last-index41618
-Ref: -find-indices42122
-Ref: -grade-up42530
-Ref: -grade-down42933
-Node: Set operations43343
-Ref: -union43526
-Ref: -difference43968
-Ref: -intersection44385
-Ref: -powerset44822
-Ref: -permutations45035
-Ref: -distinct45335
-Node: Other list operations45659
-Ref: -rotate45884
-Ref: -repeat46179
-Ref: -cons*46442
-Ref: -snoc46829
-Ref: -interpose47242
-Ref: -interleave47540
-Ref: -zip-with47909
-Ref: -zip48626
-Ref: -zip-fill49432
-Ref: -unzip49755
-Ref: -cycle50289
-Ref: -pad50662
-Ref: -table50985
-Ref: -table-flat51775
-Ref: -first52784
-Ref: -some53156
-Ref: -last53465
-Ref: -first-item53799
-Ref: -last-item54112
-Ref: -butlast54404
-Ref: -sort54651
-Ref: -list55139
-Ref: -fix55470
-Node: Tree operations56010
-Ref: -tree-seq56206
-Ref: -tree-map57064
-Ref: -tree-map-nodes57507
-Ref: -tree-reduce58362
-Ref: -tree-reduce-from59244
-Ref: -tree-mapreduce59845
-Ref: -tree-mapreduce-from60705
-Ref: -clone61991
-Node: Threading macros62319
-Ref: ->62464
-Ref: ->>62956
-Ref: -->63461
-Ref: -as->64022
-Ref: -some->64477
-Ref: -some->>64851
-Ref: -some-->65287
-Node: Binding65758
-Ref: -when-let65970
-Ref: -when-let*66455
-Ref: -if-let66983
-Ref: -if-let*67378
-Ref: -let67995
-Ref: -let*72788
-Ref: -lambda73729
-Node: Side-effects74531
-Ref: -each74725
-Ref: -each-while75132
-Ref: -each-indexed75492
-Ref: -dotimes76010
-Ref: -doto76313
-Node: Destructive operations76740
-Ref: !cons76913
-Ref: !cdr77119
-Node: Function combinators77314
-Ref: -partial77588
-Ref: -rpartial77983
-Ref: -juxt78385
-Ref: -compose78817
-Ref: -applify79375
-Ref: -on79822
-Ref: -flip80345
-Ref: -const80657
-Ref: -cut81001
-Ref: -not81487
-Ref: -orfn81797
-Ref: -andfn82231
-Ref: -iteratefn82726
-Ref: -fixfn83429
-Ref: -prodfn84998
-Node: Development86064
-Node: Contribute86413
-Node: Changes87161
-Node: Contributors90160
-Node: Index91784
+Ref: -remove10567
+Ref: -remove-first10978
+Ref: -remove-last11505
+Ref: -remove-item12026
+Ref: -non-nil12420
+Ref: -slice12579
+Ref: -take13111
+Ref: -take-last13419
+Ref: -drop13742
+Ref: -drop-last14015
+Ref: -take-while14275
+Ref: -drop-while14625
+Ref: -select-by-indices14981
+Ref: -select-columns15495
+Ref: -select-column16200
+Node: List to list16663
+Ref: -keep16855
+Ref: -concat17358
+Ref: -flatten17655
+Ref: -flatten-n18414
+Ref: -replace18801
+Ref: -replace-first19264
+Ref: -replace-last19760
+Ref: -insert-at20249
+Ref: -replace-at20576
+Ref: -update-at20971
+Ref: -remove-at21462
+Ref: -remove-at-indices21950
+Node: Reductions22532
+Ref: -reduce-from22701
+Ref: -reduce-r-from23487
+Ref: -reduce24272
+Ref: -reduce-r25080
+Ref: -count25996
+Ref: -sum26220
+Ref: -product26409
+Ref: -min26618
+Ref: -min-by26844
+Ref: -max27367
+Ref: -max-by27592
+Node: Unfolding28120
+Ref: -iterate28359
+Ref: -unfold28804
+Node: Predicates29612
+Ref: -any?29736
+Ref: -all?30056
+Ref: -none?30386
+Ref: -only-some?30688
+Ref: -contains?31173
+Ref: -same-items?31562
+Ref: -is-prefix?31947
+Ref: -is-suffix?32270
+Ref: -is-infix?32593
+Node: Partitioning32947
+Ref: -split-at33135
+Ref: -split-with33420
+Ref: -split-on33823
+Ref: -split-when34499
+Ref: -separate35139
+Ref: -partition35581
+Ref: -partition-all36033
+Ref: -partition-in-steps36461
+Ref: -partition-all-in-steps36958
+Ref: -partition-by37443
+Ref: -partition-by-header37825
+Ref: -partition-after-pred38429
+Ref: -partition-before-pred38800
+Ref: -partition-before-item39178
+Ref: -partition-after-item39489
+Ref: -group-by39795
+Node: Indexing40232
+Ref: -elem-index40434
+Ref: -elem-indices40829
+Ref: -find-index41212
+Ref: -find-last-index41701
+Ref: -find-indices42205
+Ref: -grade-up42613
+Ref: -grade-down43016
+Node: Set operations43426
+Ref: -union43609
+Ref: -difference44051
+Ref: -intersection44468
+Ref: -powerset44905
+Ref: -permutations45118
+Ref: -distinct45418
+Node: Other list operations45742
+Ref: -rotate45967
+Ref: -repeat46262
+Ref: -cons*46525
+Ref: -snoc46912
+Ref: -interpose47325
+Ref: -interleave47623
+Ref: -zip-with47992
+Ref: -zip48709
+Ref: -zip-fill49515
+Ref: -unzip49838
+Ref: -cycle50372
+Ref: -pad50745
+Ref: -table51068
+Ref: -table-flat51858
+Ref: -first52867
+Ref: -some53239
+Ref: -last53548
+Ref: -first-item53882
+Ref: -last-item54195
+Ref: -butlast54487
+Ref: -sort54734
+Ref: -list55222
+Ref: -fix55553
+Node: Tree operations56093
+Ref: -tree-seq56289
+Ref: -tree-map57147
+Ref: -tree-map-nodes57590
+Ref: -tree-reduce58445
+Ref: -tree-reduce-from59327
+Ref: -tree-mapreduce59928
+Ref: -tree-mapreduce-from60788
+Ref: -clone62074
+Node: Threading macros62402
+Ref: ->62547
+Ref: ->>63039
+Ref: -->63544
+Ref: -as->64105
+Ref: -some->64560
+Ref: -some->>64934
+Ref: -some-->65370
+Node: Binding65841
+Ref: -when-let66053
+Ref: -when-let*66538
+Ref: -if-let67066
+Ref: -if-let*67461
+Ref: -let68078
+Ref: -let*72871
+Ref: -lambda73812
+Node: Side-effects74614
+Ref: -each74808
+Ref: -each-while75215
+Ref: -each-indexed75575
+Ref: -dotimes76093
+Ref: -doto76396
+Node: Destructive operations76823
+Ref: !cons76996
+Ref: !cdr77202
+Node: Function combinators77397
+Ref: -partial77671
+Ref: -rpartial78066
+Ref: -juxt78468
+Ref: -compose78900
+Ref: -applify79458
+Ref: -on79905
+Ref: -flip80428
+Ref: -const80740
+Ref: -cut81084
+Ref: -not81570
+Ref: -orfn81880
+Ref: -andfn82314
+Ref: -iteratefn82809
+Ref: -fixfn83512
+Ref: -prodfn85081
+Node: Development86147
+Node: Contribute86496
+Node: Changes87244
+Node: Contributors90243
+Node: Index91867
 
 End Tag Table
 

--- a/dash.texi
+++ b/dash.texi
@@ -438,7 +438,7 @@ Return a new list of the items in @var{list} for which @var{pred} returns a non-
 
 Alias: @code{-select}
 
-See also: @code{-keep} (@pxref{-keep})
+See also: @code{-keep} (@pxref{-keep}), @code{-remove} (@pxref{-remove}).
 
 @example
 @group
@@ -461,6 +461,8 @@ See also: @code{-keep} (@pxref{-keep})
 Return a new list of the items in @var{list} for which @var{pred} returns nil.
 
 Alias: @code{-reject}
+
+See also: @code{-filter} (@pxref{-filter}).
 
 @example
 @group


### PR DESCRIPTION
These functions do the opposite of each other, so it's useful to
mention the other one in the docstrings.