### PR TITLE
Safer -common-prefix via breadth-first traversal

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -2118,10 +2118,7 @@ or with `-compare-fn' if that's non-nil."
 (defun -common-prefix (&rest lists)
   "Return the longest common prefix of LISTS."
   (declare (pure t) (side-effect-free t))
-  (--reduce (let (head prefix)
-              (while (and acc it (equal (setq head (pop acc)) (pop it)))
-                (push head prefix))
-              (nreverse prefix))
+  (--reduce (--take-while (and acc (equal (pop acc) it)) it)
             lists))
 
 (defun -contains? (list element)


### PR DESCRIPTION
This implementation is slightly slower than using `--reduce` under "normal" circumstances, but correctly short-circuits performance pitfalls such as

```el
(let ((l (number-sequence 0 1000)))
  (-common-prefix l l ()))
```

1. Do you think it's worth complicating the implementation to protect against such scenarios?
2. Should I annotate the various local variables used with a brief description of their purpose, or do you find this clear enough?