### PR TITLE
Implement -dolist

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -92,6 +92,22 @@ the target form."
 
 (put '-each 'lisp-indent-function 1)
 
+(defmacro -dolist (varlist &rest body)
+  "Loop over a list.
+
+Evaluate BODY with MATCH-FORM bound to each car from LIST, in turn.
+
+MATCH-FORM destructuring is done according to the rules of `-let'.
+
+See also: `dolist', `-each'.
+
+\(fn (MATCH-FORM LIST) BODY...)"
+  (declare (indent 1))
+  (let ((source (make-symbol "--dash-source--")))
+    `(dolist (,source ,(cadr varlist))
+       (-let ,(list (list (car varlist) source))
+         ,@body))))
+
 (defalias '--each-indexed '--each)
 
 (defun -each-indexed (list fn)


### PR DESCRIPTION
Fixes #136 

The syntax is as follows

```elisp
(-dolist ((first . second) '((a . b) (c . d)))
  (message "first %s second %s" first second))

;; also works as usual `dolist'
(-dolist (var '((a . b) (c . d)))
  (message "first %s" var))
```