### PR TITLE
Add the branching arrows -<, -<<, --<, and -as-<. (resubmitted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Functions reducing lists into single value.
 * [-inits](#-inits-list) `(list)`
 * [-tails](#-tails-list) `(list)`
 * [-common-prefix](#-common-prefix-rest-lists) `(&rest lists)`
+* [-common-suffix](#-common-suffix-rest-lists) `(&rest lists)`
 * [-min](#-min-list) `(list)`
 * [-min-by](#-min-by-comparator-list) `(comparator list)`
 * [-max](#-max-list) `(list)`
@@ -275,6 +276,10 @@ Functions pretending lists are trees.
 * [-some->](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [-some->>](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [-some-->](#-some---x-optional-form-rest-more) `(x &optional form &rest more)`
+* [-<](#--x-collector-rest-forms) `(x collector &rest forms)`
+* [-<<](#--x-collector-rest-forms) `(x collector &rest forms)`
+* [--<](#---x-collector-rest-forms) `(x collector &rest forms)`
+* [-as-<](#-as--x-collector-variable-rest-forms) `(x collector variable &rest forms)`
 
 ### Binding
 
@@ -1052,8 +1057,18 @@ Return the longest common prefix of `lists`.
 
 ```el
 (-common-prefix '(1)) ;; => '(1)
-(-common-prefix '(1 2) nil '(1 2)) ;; => nil
+(-common-prefix '(1 2) '(3 4) '(1 2)) ;; => nil
 (-common-prefix '(1 2) '(1 2 3) '(1 2 3 4)) ;; => '(1 2)
+```
+
+#### -common-suffix `(&rest lists)`
+
+Return the longest common suffix of `lists`.
+
+```el
+(-common-suffix '(1)) ;; => '(1)
+(-common-suffix '(1 2) '(3 4) '(1 2)) ;; => nil
+(-common-suffix '(1 2 3 4) '(2 3 4) '(3 4)) ;; => '(3 4)
 ```
 
 #### -min `(list)`
@@ -2186,6 +2201,75 @@ and when that result is non-nil, through the next form, etc.
 (-some--> "def" (concat "abc" it "ghi")) ;; => "abcdefghi"
 (-some--> nil (concat "abc" it "ghi")) ;; => nil
 (-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it)) ;; => nil
+```
+
+#### -< `(x collector &rest forms)`
+
+Thread the expr through each form in parallel. Insert `x` as the
+second item in each form, then call `collector` on the result.
+`collector` must be able to take as many arguments as the length of
+`forms`. `x` will be evaluated only once.
+
+`collector` may have short-circuiting behavior like the `and`
+special form.
+
+
+```el
+(-< '(2 3 5) list) ;; => '((2 3 5))
+(-< '(2 3 5) list (append '(8 13))) ;; => '((2 3 5 8 13))
+(-< '(2 3 5) list (append '(8 13)) (-slice 1 -1)) ;; => '((2 3 5 8 13) (3))
+```
+
+#### -<< `(x collector &rest forms)`
+
+Thread the expr through each form in parallel. Insert `x` as the
+last item in each form, then call `collector` on the result.
+`collector` must be able to take as many arguments as the length of
+`forms`. `x` will be evaluated only once.
+
+`collector` may have short-circuiting behavior like the `and`
+special form.
+
+
+```el
+(-<< '(1 2 3) list (-map 'square)) ;; => '((1 4 9))
+(-<< '(1 2 3) list (-map 'square) (-remove 'even?)) ;; => '((1 4 9) (1 3))
+(-<< '(1 2 3) list (-map 'square) (-reduce '+)) ;; => '((1 4 9) 6)
+```
+
+#### --< `(x collector &rest forms)`
+
+Thread the expr through each form in parallel.
+
+Insert `x` at the position signified by the symbol `it` in the each
+form, then call `collector` on the result. `collector` must be able
+to take as many arguments as the length of `forms`. `x` will be
+evaluated only once.
+
+`collector` may have short-circuiting behavior like the `and`
+special form. 
+
+```el
+(--< "def" list (concat "abc" it "ghi")) ;; => '("abcdefghi")
+(--< "def" list (concat "abc" it "ghi") (upcase it)) ;; => '("abcdefghi" "DEF")
+(--< "def" list (concat "abc" it "ghi") upcase) ;; => '("abcdefghi" "DEF")
+```
+
+#### -as-< `(x collector variable &rest forms)`
+
+Thread the expr through each form in parallel. Bind `variable`
+to `x` in each form, then call `collector` on the result.  `collector`
+must be able to take as many arguments as the length of `forms`. `x`
+will be evaluated only once.
+
+`collector` may have short-circuiting behavior like the `and`
+special form.
+
+
+```el
+(-as-< 3 list my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) (list my-var))) ;; => '(4 (3) (6))
+(-as-< 3 list my-var 1+) ;; => '(4)
+(-as-< 3 list my-var) ;; => '(3)
 ```
 
 

--- a/dash.el
+++ b/dash.el
@@ -1554,6 +1554,69 @@ and when that result is non-nil, through the next form, etc."
                    (--> ,result ,form))
                  ,@more))))
 
+(defmacro dash--thread-each-and-collect (op x collector &optional forms)
+  "Private: Used by -< and -<<.
+
+Returned expr: (COLLECTOR (OP X form1) (OP X form2) ...).
+If no forms were passed then returned expr would be: (COLLECTOR (OP X nil)).
+X will be evaluated only once.
+"
+  (let ((value (make-symbol "value")))
+    `(let ((,value ,x))
+       (,collector ,@(--map (list op value it)
+                            (or forms '(nil)))))))
+
+(defmacro -< (x collector &rest forms)
+  "Thread the expr through each form in parallel. Insert X as the
+second item in each form, then call COLLECTOR on the result.
+COLLECTOR must be able to take as many arguments as the length of
+FORMS. X will be evaluated only once.
+
+COLLECTOR may have short-circuiting behavior like the `and'
+special form.
+"
+  `(dash--thread-each-and-collect -> ,x ,collector ,forms))
+
+(defmacro -<< (x collector &rest forms)
+  "Thread the expr through each form in parallel. Insert X as the
+last item in each form, then call COLLECTOR on the result.
+COLLECTOR must be able to take as many arguments as the length of
+FORMS. X will be evaluated only once.
+
+COLLECTOR may have short-circuiting behavior like the `and'
+special form.
+"
+  `(dash--thread-each-and-collect ->> ,x ,collector ,forms))
+
+(defmacro -as-< (x collector variable &rest forms)
+  "Thread the expr through each form in parallel. Bind VARIABLE
+to X in each form, then call COLLECTOR on the result.  COLLECTOR
+must be able to take as many arguments as the length of FORMS. X
+will be evaluated only once.
+
+COLLECTOR may have short-circuiting behavior like the `and'
+special form.
+"
+  (cond
+    ((null forms)
+     `(,collector (-as-> ,x ,variable)))
+    (:else (let ((value (make-symbol "value")))
+             `(let ((,value ,x))
+                (,collector ,@(--map (list '-as-> value variable it)
+                                     (or forms '(nil)))))))))
+
+(defmacro --< (x collector &rest forms)
+    "Thread the expr through each form in parallel.
+
+Insert X at the position signified by the symbol `it' in the each
+form, then call COLLECTOR on the result. COLLECTOR must be able
+to take as many arguments as the length of FORMS. X will be
+evaluated only once.
+
+COLLECTOR may have short-circuiting behavior like the `and'
+special form. "
+  `(-as-< ,x ,collector it ,@forms))
+
 (defun -grade-up (comparator list)
   "Grade elements of LIST using COMPARATOR relation, yielding a
 permutation vector such that applying this permutation to LIST

--- a/dash.info
+++ b/dash.info
@@ -942,10 +942,20 @@ Functions reducing lists into single value.
 
           (-common-prefix '(1))
               ⇒ '(1)
-          (-common-prefix '(1 2) nil '(1 2))
+          (-common-prefix '(1 2) '(3 4) '(1 2))
               ⇒ nil
           (-common-prefix '(1 2) '(1 2 3) '(1 2 3 4))
               ⇒ '(1 2)
+
+ -- Function: -common-suffix (&rest lists)
+     Return the longest common suffix of LISTS.
+
+          (-common-suffix '(1))
+              ⇒ '(1)
+          (-common-suffix '(1 2) '(3 4) '(1 2))
+              ⇒ nil
+          (-common-suffix '(1 2 3 4) '(2 3 4) '(3 4))
+              ⇒ '(3 4)
 
  -- Function: -min (list)
      Return the smallest value from LIST of numbers or markers.
@@ -2110,6 +2120,72 @@ File: dash.info,  Node: Threading macros,  Next: Binding,  Prev: Tree operations
           (-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it))
               ⇒ nil
 
+ -- Macro: -< (x collector &rest forms)
+     Thread the expr through each form in parallel.  Insert X as the
+     second item in each form, then call COLLECTOR on the result.
+     COLLECTOR must be able to take as many arguments as the length of
+     FORMS.  X will be evaluated only once.
+
+     COLLECTOR may have short-circuiting behavior like the ‘and’
+     special form.
+
+          (-< '(2 3 5) list)
+              ⇒ '((2 3 5))
+          (-< '(2 3 5) list (append '(8 13)))
+              ⇒ '((2 3 5 8 13))
+          (-< '(2 3 5) list (append '(8 13)) (-slice 1 -1))
+              ⇒ '((2 3 5 8 13) (3))
+
+ -- Macro: -<< (x collector &rest forms)
+     Thread the expr through each form in parallel.  Insert X as the
+     last item in each form, then call COLLECTOR on the result.
+     COLLECTOR must be able to take as many arguments as the length of
+     FORMS.  X will be evaluated only once.
+
+     COLLECTOR may have short-circuiting behavior like the ‘and’
+     special form.
+
+          (-<< '(1 2 3) list (-map 'square))
+              ⇒ '((1 4 9))
+          (-<< '(1 2 3) list (-map 'square) (-remove 'even?))
+              ⇒ '((1 4 9) (1 3))
+          (-<< '(1 2 3) list (-map 'square) (-reduce '+))
+              ⇒ '((1 4 9) 6)
+
+ -- Macro: --< (x collector &rest forms)
+     Thread the expr through each form in parallel.
+
+     Insert X at the position signified by the symbol ‘it’ in the each
+     form, then call COLLECTOR on the result.  COLLECTOR must be able
+     to take as many arguments as the length of FORMS.  X will be
+     evaluated only once.
+
+     COLLECTOR may have short-circuiting behavior like the ‘and’
+     special form.
+
+          (--< "def" list (concat "abc" it "ghi"))
+              ⇒ '("abcdefghi")
+          (--< "def" list (concat "abc" it "ghi") (upcase it))
+              ⇒ '("abcdefghi" "DEF")
+          (--< "def" list (concat "abc" it "ghi") upcase)
+              ⇒ '("abcdefghi" "DEF")
+
+ -- Macro: -as-< (x collector variable &rest forms)
+     Thread the expr through each form in parallel.  Bind VARIABLE to
+     X in each form, then call COLLECTOR on the result.  COLLECTOR
+     must be able to take as many arguments as the length of FORMS.  X
+     will be evaluated only once.
+
+     COLLECTOR may have short-circuiting behavior like the ‘and’
+     special form.
+
+          (-as-< 3 list my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) (list my-var)))
+              ⇒ '(4 (3) (6))
+          (-as-< 3 list my-var 1+)
+              ⇒ '(4)
+          (-as-< 3 list my-var)
+              ⇒ '(3)
+
 
 File: dash.info,  Node: Binding,  Next: Side-effects,  Prev: Threading macros,  Up: Functions
 
@@ -2946,7 +3022,10 @@ Index
                                                             (line  14)
 * !cons:                                 Destructive operations.
                                                             (line   6)
+* --<:                                   Threading macros.  (line 128)
 * -->:                                   Threading macros.  (line  32)
+* -<:                                    Threading macros.  (line  96)
+* -<<:                                   Threading macros.  (line 112)
 * ->:                                    Threading macros.  (line   6)
 * ->>:                                   Threading macros.  (line  19)
 * -all?:                                 Predicates.        (line  18)
@@ -2956,11 +3035,13 @@ Index
 * -any?:                                 Predicates.        (line   6)
 * -applify:                              Function combinators.
                                                             (line  56)
+* -as-<:                                 Threading macros.  (line 146)
 * -as->:                                 Threading macros.  (line  47)
 * -butlast:                              Other list operations.
                                                             (line 311)
 * -clone:                                Tree operations.   (line 123)
 * -common-prefix:                        Reductions.        (line 224)
+* -common-suffix:                        Reductions.        (line 234)
 * -compose:                              Function combinators.
                                                             (line  42)
 * -concat:                               List to list.      (line  22)
@@ -3045,10 +3126,10 @@ Index
 * -map-last:                             Maps.              (line  52)
 * -map-when:                             Maps.              (line  21)
 * -mapcat:                               Maps.              (line 124)
-* -max:                                  Reductions.        (line 258)
-* -max-by:                               Reductions.        (line 268)
-* -min:                                  Reductions.        (line 234)
-* -min-by:                               Reductions.        (line 244)
+* -max:                                  Reductions.        (line 268)
+* -max-by:                               Reductions.        (line 278)
+* -min:                                  Reductions.        (line 244)
+* -min-by:                               Reductions.        (line 254)
 * -non-nil:                              Sublist selection. (line  80)
 * -none?:                                Predicates.        (line  30)
 * -not:                                  Function combinators.
@@ -3189,177 +3270,182 @@ Ref: -slice12579
 Ref: -take13111
 Ref: -take-last13419
 Ref: -drop13742
-Ref: -drop-last14016
-Ref: -take-while14277
-Ref: -drop-while14628
-Ref: -select-by-indices14984
-Ref: -select-columns15498
-Ref: -select-column16203
-Node: List to list16666
-Ref: -keep16858
-Ref: -concat17361
-Ref: -flatten17658
-Ref: -flatten-n18417
-Ref: -replace18804
-Ref: -replace-first19267
-Ref: -replace-last19763
-Ref: -insert-at20252
-Ref: -replace-at20579
-Ref: -update-at20974
-Ref: -remove-at21465
-Ref: -remove-at-indices21953
-Node: Reductions22535
-Ref: -reduce-from22704
-Ref: -reduce-r-from23470
-Ref: -reduce24237
-Ref: -reduce-r24971
-Ref: -reductions-from25841
-Ref: -reductions-r-from26556
-Ref: -reductions27281
-Ref: -reductions-r27906
-Ref: -count28541
-Ref: -sum28765
-Ref: -running-sum28955
-Ref: -product29249
-Ref: -running-product29459
-Ref: -inits29773
-Ref: -tails30021
-Ref: -common-prefix30268
-Ref: -min30562
-Ref: -min-by30788
-Ref: -max31311
-Ref: -max-by31536
-Node: Unfolding32064
-Ref: -iterate32303
-Ref: -unfold32748
-Node: Predicates33556
-Ref: -any?33680
-Ref: -all?34000
-Ref: -none?34330
-Ref: -only-some?34632
-Ref: -contains?35117
-Ref: -same-items?35506
-Ref: -is-prefix?35891
-Ref: -is-suffix?36214
-Ref: -is-infix?36537
-Node: Partitioning36891
-Ref: -split-at37079
-Ref: -split-with37364
-Ref: -split-on37767
-Ref: -split-when38443
-Ref: -separate39083
-Ref: -partition39525
-Ref: -partition-all39977
-Ref: -partition-in-steps40405
-Ref: -partition-all-in-steps40902
-Ref: -partition-by41387
-Ref: -partition-by-header41771
-Ref: -partition-after-pred42375
-Ref: -partition-before-pred42721
-Ref: -partition-before-item43074
-Ref: -partition-after-item43387
-Ref: -group-by43695
-Node: Indexing44134
-Ref: -elem-index44336
-Ref: -elem-indices44731
-Ref: -find-index45114
-Ref: -find-last-index45603
-Ref: -find-indices46107
-Ref: -grade-up46515
-Ref: -grade-down46918
-Node: Set operations47328
-Ref: -union47511
-Ref: -difference47954
-Ref: -intersection48374
-Ref: -powerset48815
-Ref: -permutations49029
-Ref: -distinct49330
-Node: Other list operations49656
-Ref: -rotate49881
-Ref: -repeat50176
-Ref: -cons*50439
-Ref: -snoc50826
-Ref: -interpose51239
-Ref: -interleave51539
-Ref: -zip-with51908
-Ref: -zip52625
-Ref: -zip-fill53431
-Ref: -unzip53754
-Ref: -cycle54288
-Ref: -pad54661
-Ref: -table54985
-Ref: -table-flat55775
-Ref: -first56784
-Ref: -some57156
-Ref: -last57465
-Ref: -first-item57799
-Ref: -second-item58215
-Ref: -third-item58495
-Ref: -fourth-item58773
-Ref: -fifth-item59039
-Ref: -last-item59301
-Ref: -butlast59593
-Ref: -sort59840
-Ref: -list60328
-Ref: -fix60659
-Node: Tree operations61199
-Ref: -tree-seq61395
-Ref: -tree-map62253
-Ref: -tree-map-nodes62696
-Ref: -tree-reduce63551
-Ref: -tree-reduce-from64433
-Ref: -tree-mapreduce65034
-Ref: -tree-mapreduce-from65894
-Ref: -clone67180
-Node: Threading macros67508
-Ref: ->67653
-Ref: ->>68145
-Ref: -->68650
-Ref: -as->69211
-Ref: -some->69666
-Ref: -some->>70040
-Ref: -some-->70476
-Node: Binding70947
-Ref: -when-let71159
-Ref: -when-let*71644
-Ref: -if-let72172
-Ref: -if-let*72567
-Ref: -let73184
-Ref: -let*79272
-Ref: -lambda80213
-Ref: -setq81015
-Node: Side-effects81831
-Ref: -each82025
-Ref: -each-while82432
-Ref: -each-indexed82792
-Ref: -each-r83310
-Ref: -each-r-while83743
-Ref: -dotimes84118
-Ref: -doto84421
-Node: Destructive operations84848
-Ref: !cons85021
-Ref: !cdr85227
-Node: Function combinators85423
-Ref: -partial85697
-Ref: -rpartial86092
-Ref: -juxt86494
-Ref: -compose86926
-Ref: -applify87484
-Ref: -on87915
-Ref: -flip88441
-Ref: -const88753
-Ref: -cut89097
-Ref: -not89583
-Ref: -orfn89893
-Ref: -andfn90327
-Ref: -iteratefn90822
-Ref: -fixfn91525
-Ref: -prodfn93094
-Node: Development94163
-Node: Contribute94512
-Node: Changes95260
-Node: Contributors98259
-Node: Index99883
+Ref: -drop-last14015
+Ref: -take-while14275
+Ref: -drop-while14625
+Ref: -select-by-indices14981
+Ref: -select-columns15495
+Ref: -select-column16200
+Node: List to list16663
+Ref: -keep16855
+Ref: -concat17358
+Ref: -flatten17655
+Ref: -flatten-n18414
+Ref: -replace18801
+Ref: -replace-first19264
+Ref: -replace-last19760
+Ref: -insert-at20249
+Ref: -replace-at20576
+Ref: -update-at20971
+Ref: -remove-at21462
+Ref: -remove-at-indices21950
+Node: Reductions22532
+Ref: -reduce-from22701
+Ref: -reduce-r-from23467
+Ref: -reduce24234
+Ref: -reduce-r24968
+Ref: -reductions-from25838
+Ref: -reductions-r-from26553
+Ref: -reductions27278
+Ref: -reductions-r27903
+Ref: -count28538
+Ref: -sum28762
+Ref: -running-sum28951
+Ref: -product29244
+Ref: -running-product29453
+Ref: -inits29766
+Ref: -tails30014
+Ref: -common-prefix30261
+Ref: -common-suffix30558
+Ref: -min30855
+Ref: -min-by31081
+Ref: -max31604
+Ref: -max-by31829
+Node: Unfolding32357
+Ref: -iterate32596
+Ref: -unfold33041
+Node: Predicates33849
+Ref: -any?33973
+Ref: -all?34293
+Ref: -none?34623
+Ref: -only-some?34925
+Ref: -contains?35410
+Ref: -same-items?35799
+Ref: -is-prefix?36184
+Ref: -is-suffix?36507
+Ref: -is-infix?36830
+Node: Partitioning37184
+Ref: -split-at37372
+Ref: -split-with37657
+Ref: -split-on38060
+Ref: -split-when38736
+Ref: -separate39376
+Ref: -partition39818
+Ref: -partition-all40270
+Ref: -partition-in-steps40698
+Ref: -partition-all-in-steps41195
+Ref: -partition-by41680
+Ref: -partition-by-header42062
+Ref: -partition-after-pred42666
+Ref: -partition-before-pred43037
+Ref: -partition-before-item43415
+Ref: -partition-after-item43726
+Ref: -group-by44032
+Node: Indexing44469
+Ref: -elem-index44671
+Ref: -elem-indices45066
+Ref: -find-index45449
+Ref: -find-last-index45938
+Ref: -find-indices46442
+Ref: -grade-up46850
+Ref: -grade-down47253
+Node: Set operations47663
+Ref: -union47846
+Ref: -difference48288
+Ref: -intersection48705
+Ref: -powerset49142
+Ref: -permutations49355
+Ref: -distinct49655
+Node: Other list operations49979
+Ref: -rotate50204
+Ref: -repeat50499
+Ref: -cons*50762
+Ref: -snoc51149
+Ref: -interpose51562
+Ref: -interleave51860
+Ref: -zip-with52229
+Ref: -zip52946
+Ref: -zip-fill53752
+Ref: -unzip54075
+Ref: -cycle54609
+Ref: -pad54982
+Ref: -table55305
+Ref: -table-flat56095
+Ref: -first57104
+Ref: -some57476
+Ref: -last57785
+Ref: -first-item58119
+Ref: -second-item58535
+Ref: -third-item58815
+Ref: -fourth-item59093
+Ref: -fifth-item59359
+Ref: -last-item59621
+Ref: -butlast59913
+Ref: -sort60160
+Ref: -list60648
+Ref: -fix60979
+Node: Tree operations61519
+Ref: -tree-seq61715
+Ref: -tree-map62573
+Ref: -tree-map-nodes63016
+Ref: -tree-reduce63871
+Ref: -tree-reduce-from64753
+Ref: -tree-mapreduce65354
+Ref: -tree-mapreduce-from66214
+Ref: -clone67500
+Node: Threading macros67828
+Ref: ->67973
+Ref: ->>68465
+Ref: -->68970
+Ref: -as->69531
+Ref: -some->69986
+Ref: -some->>70360
+Ref: -some-->70796
+Ref: -<71267
+Ref: -<<71884
+Ref: --<72524
+Ref: -as-<73229
+Node: Binding73864
+Ref: -when-let74076
+Ref: -when-let*74561
+Ref: -if-let75089
+Ref: -if-let*75484
+Ref: -let76101
+Ref: -let*82189
+Ref: -lambda83130
+Ref: -setq83932
+Node: Side-effects84748
+Ref: -each84942
+Ref: -each-while85349
+Ref: -each-indexed85709
+Ref: -each-r86227
+Ref: -each-r-while86660
+Ref: -dotimes87035
+Ref: -doto87338
+Node: Destructive operations87765
+Ref: !cons87938
+Ref: !cdr88144
+Node: Function combinators88339
+Ref: -partial88613
+Ref: -rpartial89008
+Ref: -juxt89410
+Ref: -compose89842
+Ref: -applify90400
+Ref: -on90847
+Ref: -flip91373
+Ref: -const91685
+Ref: -cut92029
+Ref: -not92515
+Ref: -orfn92825
+Ref: -andfn93259
+Ref: -iteratefn93754
+Ref: -fixfn94457
+Ref: -prodfn96026
+Node: Development97095
+Node: Contribute97444
+Node: Changes98192
+Node: Contributors101191
+Node: Index102815
 
 End Tag Table
 

--- a/dash.texi
+++ b/dash.texi
@@ -1425,12 +1425,32 @@ Return the longest common prefix of @var{lists}.
     @result{} '(1)
 @end group
 @group
-(-common-prefix '(1 2) nil '(1 2))
+(-common-prefix '(1 2) '(3 4) '(1 2))
     @result{} nil
 @end group
 @group
 (-common-prefix '(1 2) '(1 2 3) '(1 2 3 4))
     @result{} '(1 2)
+@end group
+@end example
+@end defun
+
+@anchor{-common-suffix}
+@defun -common-suffix (&rest lists)
+Return the longest common suffix of @var{lists}.
+
+@example
+@group
+(-common-suffix '(1))
+    @result{} '(1)
+@end group
+@group
+(-common-suffix '(1 2) '(3 4) '(1 2))
+    @result{} nil
+@end group
+@group
+(-common-suffix '(1 2 3 4) '(2 3 4) '(3 4))
+    @result{} '(3 4)
 @end group
 @end example
 @end defun
@@ -3386,6 +3406,115 @@ and when that result is non-nil, through the next form, etc.
 @group
 (-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it))
     @result{} nil
+@end group
+@end example
+@end defmac
+
+@anchor{-<}
+@defmac -< (x collector &rest forms)
+Thread the expr through each form in parallel. Insert @var{x} as the
+second item in each form, then call @var{collector} on the result.
+@var{collector} must be able to take as many arguments as the length of
+@var{forms}. @var{x} will be evaluated only once.
+
+@var{collector} may have short-circuiting behavior like the @code{and}
+special form.
+
+
+@example
+@group
+(-< '(2 3 5) list)
+    @result{} '((2 3 5))
+@end group
+@group
+(-< '(2 3 5) list (append '(8 13)))
+    @result{} '((2 3 5 8 13))
+@end group
+@group
+(-< '(2 3 5) list (append '(8 13)) (-slice 1 -1))
+    @result{} '((2 3 5 8 13) (3))
+@end group
+@end example
+@end defmac
+
+@anchor{-<<}
+@defmac -<< (x collector &rest forms)
+Thread the expr through each form in parallel. Insert @var{x} as the
+last item in each form, then call @var{collector} on the result.
+@var{collector} must be able to take as many arguments as the length of
+@var{forms}. @var{x} will be evaluated only once.
+
+@var{collector} may have short-circuiting behavior like the @code{and}
+special form.
+
+
+@example
+@group
+(-<< '(1 2 3) list (-map 'square))
+    @result{} '((1 4 9))
+@end group
+@group
+(-<< '(1 2 3) list (-map 'square) (-remove 'even?))
+    @result{} '((1 4 9) (1 3))
+@end group
+@group
+(-<< '(1 2 3) list (-map 'square) (-reduce '+))
+    @result{} '((1 4 9) 6)
+@end group
+@end example
+@end defmac
+
+@anchor{--<}
+@defmac --< (x collector &rest forms)
+Thread the expr through each form in parallel.
+
+Insert @var{x} at the position signified by the symbol @code{it} in the each
+form, then call @var{collector} on the result. @var{collector} must be able
+to take as many arguments as the length of @var{forms}. @var{x} will be
+evaluated only once.
+
+@var{collector} may have short-circuiting behavior like the @code{and}
+special form. 
+
+@example
+@group
+(--< "def" list (concat "abc" it "ghi"))
+    @result{} '("abcdefghi")
+@end group
+@group
+(--< "def" list (concat "abc" it "ghi") (upcase it))
+    @result{} '("abcdefghi" "DEF")
+@end group
+@group
+(--< "def" list (concat "abc" it "ghi") upcase)
+    @result{} '("abcdefghi" "DEF")
+@end group
+@end example
+@end defmac
+
+@anchor{-as-<}
+@defmac -as-< (x collector variable &rest forms)
+Thread the expr through each form in parallel. Bind @var{variable}
+to @var{x} in each form, then call @var{collector} on the result.  @var{collector}
+must be able to take as many arguments as the length of @var{forms}. @var{x}
+will be evaluated only once.
+
+@var{collector} may have short-circuiting behavior like the @code{and}
+special form.
+
+
+@example
+@group
+(-as-< 3 list my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) (list my-var)))
+    @result{} '(4 (3) (6))
+@end group
+@group
+(-as-< 3 list my-var 1+)
+    @result{} '(4)
+@end group
+@group
+(-as-< 3 list my-var)
+    @result{} '(3)
 @end group
 @end example
 @end defmac

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -979,7 +979,53 @@ new list."
     (-some--> "def" (concat "abc" it "ghi")) => "abcdefghi"
     (-some--> nil (concat "abc" it "ghi")) => nil
     (-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it)) => nil
-    (-some--> '(2 4 6) (-filter 'even? it) (append it it) (-map 'square it)) => '(4 16 36 4 16 36)))
+    (-some--> '(2 4 6) (-filter 'even? it) (append it it) (-map 'square it)) => '(4 16 36 4 16 36))
+
+  (defexamples -<
+    (-< '(2 3 5) list) => '((2 3 5))
+    (-< '(2 3 5) list (append '(8 13))) => '((2 3 5 8 13))
+    (-< '(2 3 5) list (append '(8 13)) (-slice 1 -1)) => '((2 3 5 8 13) (3))
+    (-< 5 list square) => '(25)
+    (-< 5 list (+ 3) square) => '(8 25)
+    (-< (+ 1 2) list (list 2) (list 3) (list 4)) => '((3 2) (3 3) (3 4))
+    (-< (+ 1 2) list (-> (* 2) list) (list 4)) => '((6) (3 4))
+    (-< 8 and integer-or-marker-p even?) => t)
+
+  (defexamples -<<
+    (-<< '(1 2 3) list (-map 'square)) => '((1 4 9))
+    (-<< '(1 2 3) list (-map 'square) (-remove 'even?)) => '((1 4 9) (1 3))
+    (-<< '(1 2 3) list (-map 'square) (-reduce '+)) => '((1 4 9) 6)
+    (-<< 5 list (- 8)) => '(3)
+    (-<< 5 list (- 3) square) => '(-2 25)
+    (-<< (+ 1 2) list (list 2 1) (list 5 7) (list 9 4)) => '((2 1 3) (5 7 3) (9 4 3)))
+
+  (defexamples --<
+    (--< "def" list (concat "abc" it "ghi")) => '("abcdefghi")
+    (--< "def" list (concat "abc" it "ghi") (upcase it)) => '("abcdefghi" "DEF")
+    (--< "def" list (concat "abc" it "ghi") upcase) => '("abcdefghi" "DEF")
+    (--< "def" list upcase) => '("DEF")
+    (--< 3 list (car (list it))) => '(3)
+
+    (--< '(1 2 3 4) list (--map (1+ it) it)) => '((2 3 4 5))
+    (--map (--< it list (1+ it)) '(1 2 3 4)) => '((2) (3) (4) (5))
+
+    (--< '(1 2 3 4) list (--filter (equal 0 (mod it 2)) it)) => '((2 4))
+
+    (--< '(0 1 2 3) list (--annotate (< 1 it) it)) => '(((nil . 0)
+                                                         (nil . 1)
+                                                         (t . 2)
+                                                         (t . 3)))
+
+    (--< (+ 1 2) list (list it 2 1) (list 5 it 7) (list 9 4 it)) => '((3 2 1) (5 3 7) (9 4 3)))
+
+   (defexamples -as-<
+    (-as-< 3 list my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) (list my-var))) => '(4 (3) (6))
+    (-as-< 3 list my-var 1+) => '(4)
+    (-as-< 3 list my-var) => '(3)
+    (-as-< "def" list string (concat "abc" string "ghi")) => '("abcdefghi")
+    (-as-< "def" list string (concat "abc" string "ghi") upcase) => '("abcdefghi" "DEF")
+    (-as-< "def" list string (concat "abc" string "ghi") (upcase string)) => '("abcdefghi" "DEF")
+    (-as-< (+ 1 2) list my-var (list my-var 2 1) (list 5 my-var 7) (list 9 4 my-var)) => '((3 2 1) (5 3 7) (9 4 3))))
 
 (def-example-group "Binding"
   "Convenient versions of `let` and `let*` constructs combined with flow control."


### PR DESCRIPTION
Note: I had to resubmit a new pull request instead of https://github.com/magnars/dash.el/pull/279 because the previous pull request cannot be reopened.

Add parallel-threading macros inspired by https://github.com/rplevy/swiss-arrows. The general idea is the to complement the existing threading macros, which apply forms in sequence, to provide similar macros that apply forms in parallel. 

For example: `(-< 3 list 1+ 1- (* 2))` will produce `(4 2 6)`, and `(-< 3 + 1+ 1- (* 2))` will produce `12`. The syntax is similar to the sequential threading macros (->, ->>, etc.) except that an extra parameter is needed: the "collector" that will take the forms as arguments. This choice was made, instead of returning a list, to allow for short-circuiting special forms like `and` to be used.

The use case I've personally encountered that motivated me to implement this was the need to pass the same value to several predicates and combine these predicates using `and`:

```el
(and (listp element)
        (-> element length (>= 2))
        (-> element car atom)
        (-> element cadr alistp)
       element)
```

could be written as:

```el
(-< element and
      listp
      (-> length (>= 2))
      (-> car atom)
      (-> cadr alistp)
      identity))
```
