### PR TITLE
Generalize `-rotate` for `|n|` greater than `(length list)`.

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -921,9 +921,11 @@ See also: `-drop'"
   "Rotate LIST N places to the right.  With N negative, rotate to the left.
 The time complexity is O(n)."
   (declare (pure t) (side-effect-free t))
-  (if (> n 0)
-      (append (last list n) (butlast list n))
-    (append (-drop (- n) list) (-take (- n) list))))
+  (when list
+    (let* ((len (length list))
+           (n-mod-len (mod n len))
+           (new-tail-len (- len n-mod-len)))
+      (append (-drop new-tail-len list) (-take new-tail-len list)))))
 
 (defun -insert-at (n x list)
   "Return a list with X inserted into LIST at position N.

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -694,7 +694,9 @@ new list."
 
   (defexamples -rotate
     (-rotate 3 '(1 2 3 4 5 6 7)) => '(5 6 7 1 2 3 4)
-    (-rotate -3 '(1 2 3 4 5 6 7)) => '(4 5 6 7 1 2 3))
+    (-rotate -3 '(1 2 3 4 5 6 7)) => '(4 5 6 7 1 2 3)
+    (-rotate 16 '(1 2 3 4 5 6 7)) => '(6 7 1 2 3 4 5)
+    (-rotate -16 '(1 2 3 4 5 6 7)) => '(3 4 5 6 7 1 2))
 
   (defexamples -repeat
     (-repeat 3 :a) => '(:a :a :a)


### PR DESCRIPTION
Closes #284.

This works but is probably not idiomatic; I'd appreciate suggestions on how to tidy it up.