### PR TITLE
Add autoload cookie

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -43,6 +43,7 @@
     (dash-enable-font-lock))
   (set-default symbol value))
 
+;;;###autoload
 (defcustom dash-enable-fontlock nil
   "If non-nil, enable fontification of dash functions, macros and
 special values."


### PR DESCRIPTION
resolve #298

Now, dash.el will be loaded when `dash-enable-fontlock` is set.

```
$ emacs -batch -eval '(package-install-file "/path/to/modified/dash.el")'
$ emacs -Q -f package-initialize --eval "(custom-set-variables '(dash-enable-fontlock t))"
```
