### PR TITLE
Add dash-fontify-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,20 @@ To get function combinators:
   cons-cell return value, use `-zip-pair` instead.  During the 2.x
   release cycle the new API is available as `-zip-lists`.
 
-## Syntax highlighting of dash functions
+## Fontification of special variables
 
-Font lock of dash functions in emacs lisp buffers is now optional.
-Include this in your emacs settings to get syntax highlighting:
+Font lock of special Dash variables (`it`, `acc`, etc.) in Emacs Lisp
+buffers can optionally be enabled with the autoloaded minor mode
+`dash-fontify-mode`.  In older Emacs versions which do not dynamically
+detect macros, the minor mode also fontifies Dash macro calls.
 
-    (eval-after-load 'dash '(dash-enable-font-lock))
+To automatically enable the minor mode in all Emacs Lisp buffers, just
+call its autoloaded global counterpart `global-dash-fontify-mode`,
+either interactively or from your `user-init-file`:
+
+```el
+(global-dash-fontify-mode)
+```
 
 ## Functions
 

--- a/dash-template.texi
+++ b/dash-template.texi
@@ -62,7 +62,7 @@ along with this program.  If not, see @uref{http://www.gnu.org/licenses/}.
 Installation
 
 * Using in a package::
-* Syntax highlighting of dash functions::
+* Fontification of special variables::
 
 Functions
 
@@ -99,7 +99,7 @@ Alternatively, you can just dump @verb{~dash.el~} or
 
 @menu
 * Using in a package::
-* Syntax highlighting of dash functions::
+* Fontification of special variables::
 @end menu
 
 @node Using in a package
@@ -117,14 +117,22 @@ Add this to the big comment block at the top:
 ;; Package-Requires: ((dash "2.12.1") (dash-functional "1.2.0") (emacs "24"))
 @end lisp
 
-@node Syntax highlighting of dash functions
-@section Syntax highlighting of dash functions
+@node Fontification of special variables
+@section Fontification of special variables
 
-Font lock of dash functions in emacs lisp buffers is now optional.
-Include this in your emacs settings to get syntax highlighting:
+Font lock of special Dash variables (@code{it}, @code{acc}, etc.@:) in
+Emacs Lisp buffers can optionally be enabled with the autoloaded minor
+mode @code{dash-fontify-mode}.  In older Emacs versions which do not
+dynamically detect macros, the minor mode also fontifies Dash macro
+calls.
+
+To automatically enable the minor mode in all Emacs Lisp buffers, just
+call its autoloaded global counterpart
+@code{global-dash-fontify-mode}, either interactively or from your
+@code{user-init-file}:
 
 @lisp
-(eval-after-load 'dash '(dash-enable-font-lock))
+(global-dash-fontify-mode)
 @end lisp
 
 @node Functions

--- a/dash.el
+++ b/dash.el
@@ -45,18 +45,6 @@
   :group 'lisp
   :prefix "dash-")
 
-(defun dash--enable-fontlock (symbol value)
-  (when value
-    (dash-enable-font-lock))
-  (set-default symbol value))
-
-(defcustom dash-enable-fontlock nil
-  "If non-nil, enable fontification of dash functions, macros and
-special values."
-  :type 'boolean
-  :set 'dash--enable-fontlock
-  :group 'dash)
-
 (defmacro !cons (car cdr)
   "Destructive: Set CDR to the cons of CAR and CDR."
   `(setq ,cdr (cons ,car ,cdr)))
@@ -2776,298 +2764,157 @@ structure such as plist or alist."
   (declare (pure t) (side-effect-free t))
   (-tree-map 'identity list))
 
-(defun dash-enable-font-lock ()
-  "Add syntax highlighting to dash functions, macros and magic values."
-  (eval-after-load 'lisp-mode
-    '(progn
-       (let ((new-keywords '(
-                             "!cons"
-                             "!cdr"
-                             "-each"
-                             "--each"
-                             "-each-indexed"
-                             "--each-indexed"
-                             "-each-while"
-                             "--each-while"
-                             "-doto"
-                             "-dotimes"
-                             "--dotimes"
-                             "-map"
-                             "--map"
-                             "-reduce-from"
-                             "--reduce-from"
-                             "-reduce"
-                             "--reduce"
-                             "-reduce-r-from"
-                             "--reduce-r-from"
-                             "-reduce-r"
-                             "--reduce-r"
-                             "-reductions-from"
-                             "-reductions-r-from"
-                             "-reductions"
-                             "-reductions-r"
-                             "-filter"
-                             "--filter"
-                             "-select"
-                             "--select"
-                             "-remove"
-                             "--remove"
-                             "-reject"
-                             "--reject"
-                             "-remove-first"
-                             "--remove-first"
-                             "-reject-first"
-                             "--reject-first"
-                             "-remove-last"
-                             "--remove-last"
-                             "-reject-last"
-                             "--reject-last"
-                             "-remove-item"
-                             "-non-nil"
-                             "-keep"
-                             "--keep"
-                             "-map-indexed"
-                             "--map-indexed"
-                             "-splice"
-                             "--splice"
-                             "-splice-list"
-                             "--splice-list"
-                             "-map-when"
-                             "--map-when"
-                             "-replace-where"
-                             "--replace-where"
-                             "-map-first"
-                             "--map-first"
-                             "-map-last"
-                             "--map-last"
-                             "-replace"
-                             "-replace-first"
-                             "-replace-last"
-                             "-flatten"
-                             "-flatten-n"
-                             "-concat"
-                             "-mapcat"
-                             "--mapcat"
-                             "-copy"
-                             "-cons*"
-                             "-snoc"
-                             "-first"
-                             "--first"
-                             "-find"
-                             "--find"
-                             "-some"
-                             "--some"
-                             "-any"
-                             "--any"
-                             "-last"
-                             "--last"
-                             "-first-item"
-                             "-second-item"
-                             "-third-item"
-                             "-fourth-item"
-                             "-fifth-item"
-                             "-last-item"
-                             "-butlast"
-                             "-count"
-                             "--count"
-                             "-any?"
-                             "--any?"
-                             "-some?"
-                             "--some?"
-                             "-any-p"
-                             "--any-p"
-                             "-some-p"
-                             "--some-p"
-                             "-some->"
-                             "-some->>"
-                             "-some-->"
-                             "-all?"
-                             "-all-p"
-                             "--all?"
-                             "--all-p"
-                             "-every?"
-                             "--every?"
-                             "-all-p"
-                             "--all-p"
-                             "-every-p"
-                             "--every-p"
-                             "-none?"
-                             "--none?"
-                             "-none-p"
-                             "--none-p"
-                             "-only-some?"
-                             "--only-some?"
-                             "-only-some-p"
-                             "--only-some-p"
-                             "-slice"
-                             "-take"
-                             "-drop"
-                             "-drop-last"
-                             "-take-last"
-                             "-take-while"
-                             "--take-while"
-                             "-drop-while"
-                             "--drop-while"
-                             "-split-at"
-                             "-rotate"
-                             "-insert-at"
-                             "-replace-at"
-                             "-update-at"
-                             "--update-at"
-                             "-remove-at"
-                             "-remove-at-indices"
-                             "-split-with"
-                             "--split-with"
-                             "-split-on"
-                             "-split-when"
-                             "--split-when"
-                             "-separate"
-                             "--separate"
-                             "-partition-all-in-steps"
-                             "-partition-in-steps"
-                             "-partition-all"
-                             "-partition"
-                             "-partition-after-item"
-                             "-partition-after-pred"
-                             "-partition-before-item"
-                             "-partition-before-pred"
-                             "-partition-by"
-                             "--partition-by"
-                             "-partition-by-header"
-                             "--partition-by-header"
-                             "-group-by"
-                             "--group-by"
-                             "-interpose"
-                             "-interleave"
-                             "-unzip"
-                             "-zip-with"
-                             "--zip-with"
-                             "-zip"
-                             "-zip-fill"
-                             "-zip-lists"
-                             "-zip-pair"
-                             "-cycle"
-                             "-pad"
-                             "-annotate"
-                             "--annotate"
-                             "-table"
-                             "-table-flat"
-                             "-partial"
-                             "-elem-index"
-                             "-elem-indices"
-                             "-find-indices"
-                             "--find-indices"
-                             "-find-index"
-                             "--find-index"
-                             "-find-last-index"
-                             "--find-last-index"
-                             "-select-by-indices"
-                             "-select-columns"
-                             "-select-column"
-                             "-grade-up"
-                             "-grade-down"
-                             "->"
-                             "->>"
-                             "-->"
-                             "-as->"
-                             "-when-let"
-                             "-when-let*"
-                             "--when-let"
-                             "-if-let"
-                             "-if-let*"
-                             "--if-let"
-                             "-let*"
-                             "-let"
-                             "-lambda"
-                             "-distinct"
-                             "-uniq"
-                             "-union"
-                             "-intersection"
-                             "-difference"
-                             "-powerset"
-                             "-permutations"
-                             "-inits"
-                             "-tails"
-                             "-common-prefix"
-                             "-common-suffix"
-                             "-contains?"
-                             "-contains-p"
-                             "-same-items?"
-                             "-same-items-p"
-                             "-is-prefix-p"
-                             "-is-prefix?"
-                             "-is-suffix-p"
-                             "-is-suffix?"
-                             "-is-infix-p"
-                             "-is-infix?"
-                             "-sort"
-                             "--sort"
-                             "-list"
-                             "-repeat"
-                             "-sum"
-                             "-running-sum"
-                             "-product"
-                             "-running-product"
-                             "-max"
-                             "-min"
-                             "-max-by"
-                             "--max-by"
-                             "-min-by"
-                             "--min-by"
-                             "-iterate"
-                             "--iterate"
-                             "-fix"
-                             "--fix"
-                             "-unfold"
-                             "--unfold"
-                             "-cons-pair?"
-                             "-cons-pair-p"
-                             "-cons-to-list"
-                             "-value-to-list"
-                             "-tree-mapreduce-from"
-                             "--tree-mapreduce-from"
-                             "-tree-mapreduce"
-                             "--tree-mapreduce"
-                             "-tree-map"
-                             "--tree-map"
-                             "-tree-reduce-from"
-                             "--tree-reduce-from"
-                             "-tree-reduce"
-                             "--tree-reduce"
-                             "-tree-seq"
-                             "--tree-seq"
-                             "-tree-map-nodes"
-                             "--tree-map-nodes"
-                             "-clone"
-                             "-rpartial"
-                             "-juxt"
-                             "-applify"
-                             "-on"
-                             "-flip"
-                             "-const"
-                             "-cut"
-                             "-orfn"
-                             "-andfn"
-                             "-iteratefn"
-                             "-fixfn"
-                             "-prodfn"
-                             ))
-             (special-variables '(
-                                  "it"
-                                  "it-index"
-                                  "acc"
-                                  "other"
-                                  )))
-         (font-lock-add-keywords 'emacs-lisp-mode `((,(concat "\\_<" (regexp-opt special-variables 'paren) "\\_>")
-                                                     1 font-lock-variable-name-face)) 'append)
-         (font-lock-add-keywords 'emacs-lisp-mode `((,(concat "(\\s-*" (regexp-opt new-keywords 'paren) "\\_>")
-                                                     1 font-lock-keyword-face)) 'append))
-       (--each (buffer-list)
-         (with-current-buffer it
-           (when (and (eq major-mode 'emacs-lisp-mode)
-                      (boundp 'font-lock-mode)
-                      font-lock-mode)
-             (font-lock-refresh-defaults)))))))
+;;; Font lock
+
+(defvar dash--keywords
+  `(;; TODO: Do not fontify the following automatic variables
+    ;; globally; detect and limit to their local anaphoric scope.
+    (,(concat "\\_<" (regexp-opt '("acc" "it" "it-index" "other")) "\\_>")
+     0 font-lock-variable-name-face)
+    ;; Elisp macro fontification was static prior to Emacs 25.
+    ,@(when (< emacs-major-version 25)
+        (let ((macs '("!cdr"
+                      "!cons"
+                      "-->"
+                      "--all?"
+                      "--annotate"
+                      "--any?"
+                      "--count"
+                      "--dotimes"
+                      "--doto"
+                      "--drop-while"
+                      "--each"
+                      "--each-r"
+                      "--each-r-while"
+                      "--each-while"
+                      "--filter"
+                      "--find-index"
+                      "--find-indices"
+                      "--find-last-index"
+                      "--first"
+                      "--fix"
+                      "--group-by"
+                      "--if-let"
+                      "--iterate"
+                      "--keep"
+                      "--last"
+                      "--map"
+                      "--map-first"
+                      "--map-indexed"
+                      "--map-last"
+                      "--map-when"
+                      "--mapcat"
+                      "--max-by"
+                      "--min-by"
+                      "--none?"
+                      "--only-some?"
+                      "--partition-by"
+                      "--partition-by-header"
+                      "--reduce"
+                      "--reduce-from"
+                      "--reduce-r"
+                      "--reduce-r-from"
+                      "--remove"
+                      "--remove-first"
+                      "--remove-last"
+                      "--separate"
+                      "--some"
+                      "--sort"
+                      "--splice"
+                      "--splice-list"
+                      "--split-when"
+                      "--split-with"
+                      "--take-while"
+                      "--tree-map"
+                      "--tree-map-nodes"
+                      "--tree-mapreduce"
+                      "--tree-mapreduce-from"
+                      "--tree-reduce"
+                      "--tree-reduce-from"
+                      "--tree-seq"
+                      "--unfold"
+                      "--update-at"
+                      "--when-let"
+                      "--zip-with"
+                      "->"
+                      "->>"
+                      "-as->"
+                      "-doto"
+                      "-if-let"
+                      "-if-let*"
+                      "-lambda"
+                      "-let"
+                      "-let*"
+                      "-setq"
+                      "-some-->"
+                      "-some->"
+                      "-some->>"
+                      "-split-on"
+                      "-when-let"
+                      "-when-let*")))
+          `((,(concat "(" (regexp-opt macs 'symbols)) . 1)))))
+  "Font lock keywords for `dash-fontify-mode'.")
+
+(defcustom dash-fontify-mode-lighter nil
+  "Mode line lighter for `dash-fontify-mode'.
+Either a string to display in the mode line when
+`dash-fontify-mode' is on, or nil to display
+nothing (the default)."
+  :package-version '(dash . "2.18.0")
+  :group 'dash
+  :type '(choice (string :tag "Lighter" :value " Dash")
+                 (const :tag "Nothing" nil)))
+
+;;;###autoload
+(define-minor-mode dash-fontify-mode
+  "Toggle fontification of Dash special variables.
+
+Dash-Fontify mode is a buffer-local minor mode intended for Emacs
+Lisp buffers.  Enabling it causes the special variables bound in
+anaphoric Dash macros to be fontified.  These anaphoras include
+`it', `it-index', `acc', and `other'.  In older Emacs versions
+which do not dynamically detect macros, Dash-Fontify mode
+additionally fontifies Dash macro calls.
+
+See also `dash-fontify-mode-lighter' and
+`global-dash-fontify-mode'."
+  :group 'dash :lighter dash-fontify-mode-lighter
+  (if dash-fontify-mode
+      (font-lock-add-keywords nil dash--keywords t)
+    (font-lock-remove-keywords nil dash--keywords))
+  (cond ((fboundp 'font-lock-flush) ;; Added in Emacs 25.
+         (font-lock-flush))
+        ;; `font-lock-fontify-buffer' unconditionally enables
+        ;; `font-lock-mode' and is marked `interactive-only' in later
+        ;; Emacs versions which have `font-lock-flush', so we guard
+        ;; and pacify as needed, respectively.
+        (font-lock-mode
+         (with-no-warnings
+           (font-lock-fontify-buffer)))))
+
+(defun dash--turn-on-fontify-mode ()
+  "Enable `dash-fontify-mode' if in an Emacs Lisp buffer."
+  (when (derived-mode-p #'emacs-lisp-mode)
+    (dash-fontify-mode)))
+
+;;;###autoload
+(define-globalized-minor-mode global-dash-fontify-mode
+  dash-fontify-mode dash--turn-on-fontify-mode
+  :group 'dash)
+
+(defcustom dash-enable-fontlock nil
+  "If non-nil, fontify Dash macro calls and special variables."
+  :group 'dash
+  :set (lambda (sym val)
+         (set-default sym val)
+         (global-dash-fontify-mode (if val 1 0)))
+  :type 'boolean)
+
+(make-obsolete-variable
+ 'dash-enable-fontlock #'global-dash-fontify-mode "2.18.0")
+
+(define-obsolete-function-alias
+  'dash-enable-font-lock #'global-dash-fontify-mode "2.17.0")
 
 (provide 'dash)
 ;;; dash.el ends here

--- a/dash.info
+++ b/dash.info
@@ -58,7 +58,7 @@ This manual is for ‘dash.el’ version 2.12.1.
 Installation
 
 * Using in a package::
-* Syntax highlighting of dash functions::
+* Fontification of special variables::
 
 Functions
 
@@ -106,10 +106,10 @@ your load path somewhere.
 * Menu:
 
 * Using in a package::
-* Syntax highlighting of dash functions::
+* Fontification of special variables::
 
 
-File: dash.info,  Node: Using in a package,  Next: Syntax highlighting of dash functions,  Up: Installation
+File: dash.info,  Node: Using in a package,  Next: Fontification of special variables,  Up: Installation
 
 1.1 Using in a package
 ======================
@@ -123,15 +123,22 @@ To get function combinators:
      ;; Package-Requires: ((dash "2.12.1") (dash-functional "1.2.0") (emacs "24"))
 
 
-File: dash.info,  Node: Syntax highlighting of dash functions,  Prev: Using in a package,  Up: Installation
+File: dash.info,  Node: Fontification of special variables,  Prev: Using in a package,  Up: Installation
 
-1.2 Syntax highlighting of dash functions
-=========================================
+1.2 Fontification of special variables
+======================================
 
-Font lock of dash functions in emacs lisp buffers is now optional.
-Include this in your emacs settings to get syntax highlighting:
+Font lock of special Dash variables (‘it’, ‘acc’, etc.) in Emacs Lisp
+buffers can optionally be enabled with the autoloaded minor mode
+‘dash-fontify-mode’.  In older Emacs versions which do not dynamically
+detect macros, the minor mode also fontifies Dash macro calls.
 
-     (eval-after-load 'dash '(dash-enable-font-lock))
+   To automatically enable the minor mode in all Emacs Lisp buffers,
+just call its autoloaded global counterpart
+‘global-dash-fontify-mode’, either interactively or from your
+‘user-init-file’:
+
+     (global-dash-fontify-mode)
 
 
 File: dash.info,  Node: Functions,  Next: Development,  Prev: Installation,  Up: Top
@@ -3215,206 +3222,206 @@ Index
 
 Tag Table:
 Node: Top946
-Node: Installation2425
-Node: Using in a package2995
-Node: Syntax highlighting of dash functions3359
-Node: Functions3742
-Node: Maps4953
-Ref: -map5248
-Ref: -map-when5589
-Ref: -map-first6172
-Ref: -map-last6650
-Ref: -map-indexed7123
-Ref: -annotate7603
-Ref: -splice8093
-Ref: -splice-list8874
-Ref: -mapcat9336
-Ref: -copy9712
-Node: Sublist selection9916
-Ref: -filter10109
-Ref: -remove10561
-Ref: -remove-first10972
-Ref: -remove-last11499
-Ref: -remove-item12020
-Ref: -non-nil12415
-Ref: -slice12574
-Ref: -take13106
-Ref: -take-last13414
-Ref: -drop13737
-Ref: -drop-last14010
-Ref: -take-while14270
-Ref: -drop-while14620
-Ref: -select-by-indices14976
-Ref: -select-columns15490
-Ref: -select-column16195
-Node: List to list16658
-Ref: -keep16850
-Ref: -concat17353
-Ref: -flatten17650
-Ref: -flatten-n18409
-Ref: -replace18796
-Ref: -replace-first19259
-Ref: -replace-last19756
-Ref: -insert-at20246
-Ref: -replace-at20573
-Ref: -update-at20968
-Ref: -remove-at21459
-Ref: -remove-at-indices21947
-Node: Reductions22529
-Ref: -reduce-from22698
-Ref: -reduce-r-from23464
-Ref: -reduce24231
-Ref: -reduce-r24965
-Ref: -reductions-from25835
-Ref: -reductions-r-from26550
-Ref: -reductions27275
-Ref: -reductions-r27900
-Ref: -count28535
-Ref: -sum28759
-Ref: -running-sum28948
-Ref: -product29241
-Ref: -running-product29450
-Ref: -inits29763
-Ref: -tails30011
-Ref: -common-prefix30258
-Ref: -common-suffix30555
-Ref: -min30852
-Ref: -min-by31078
-Ref: -max31601
-Ref: -max-by31826
-Node: Unfolding32354
-Ref: -iterate32593
-Ref: -unfold33038
-Node: Predicates33846
-Ref: -any?33970
-Ref: -all?34290
-Ref: -none?34620
-Ref: -only-some?34922
-Ref: -contains?35407
-Ref: -same-items?35796
-Ref: -is-prefix?36181
-Ref: -is-suffix?36504
-Ref: -is-infix?36827
-Node: Partitioning37181
-Ref: -split-at37369
-Ref: -split-with37654
-Ref: -split-on38057
-Ref: -split-when38733
-Ref: -separate39373
-Ref: -partition39815
-Ref: -partition-all40267
-Ref: -partition-in-steps40695
-Ref: -partition-all-in-steps41192
-Ref: -partition-by41677
-Ref: -partition-by-header42059
-Ref: -partition-after-pred42663
-Ref: -partition-before-pred43007
-Ref: -partition-before-item43358
-Ref: -partition-after-item43669
-Ref: -group-by43975
-Node: Indexing44412
-Ref: -elem-index44614
-Ref: -elem-indices45009
-Ref: -find-index45392
-Ref: -find-last-index45881
-Ref: -find-indices46385
-Ref: -grade-up46793
-Ref: -grade-down47196
-Node: Set operations47606
-Ref: -union47789
-Ref: -difference48231
-Ref: -intersection48648
-Ref: -powerset49085
-Ref: -permutations49298
-Ref: -distinct49598
-Node: Other list operations49976
-Ref: -rotate50201
-Ref: -repeat50571
-Ref: -cons*50834
-Ref: -snoc51221
-Ref: -interpose51634
-Ref: -interleave51932
-Ref: -zip-with52301
-Ref: -zip53018
-Ref: -zip-lists53850
-Ref: -zip-fill54551
-Ref: -unzip54874
-Ref: -cycle55619
-Ref: -pad55992
-Ref: -table56315
-Ref: -table-flat57105
-Ref: -first58114
-Ref: -some58486
-Ref: -last58795
-Ref: -first-item59129
-Ref: -second-item59545
-Ref: -third-item59825
-Ref: -fourth-item60103
-Ref: -fifth-item60369
-Ref: -last-item60631
-Ref: -butlast60923
-Ref: -sort61170
-Ref: -list61658
-Ref: -fix61989
-Node: Tree operations62529
-Ref: -tree-seq62725
-Ref: -tree-map63583
-Ref: -tree-map-nodes64026
-Ref: -tree-reduce64881
-Ref: -tree-reduce-from65763
-Ref: -tree-mapreduce66364
-Ref: -tree-mapreduce-from67224
-Ref: -clone68510
-Node: Threading macros68838
-Ref: ->68983
-Ref: ->>69475
-Ref: -->69980
-Ref: -as->70541
-Ref: -some->70996
-Ref: -some->>71370
-Ref: -some-->71806
-Node: Binding72277
-Ref: -when-let72489
-Ref: -when-let*72974
-Ref: -if-let73502
-Ref: -if-let*73897
-Ref: -let74514
-Ref: -let*80602
-Ref: -lambda81543
-Ref: -setq82345
-Node: Side-effects83161
-Ref: -each83355
-Ref: -each-while83762
-Ref: -each-indexed84122
-Ref: -each-r84640
-Ref: -each-r-while85073
-Ref: -dotimes85448
-Ref: -doto85751
-Ref: --doto86178
-Node: Destructive operations86453
-Ref: !cons86626
-Ref: !cdr86832
-Node: Function combinators87027
-Ref: -partial87301
-Ref: -rpartial87694
-Ref: -juxt88096
-Ref: -compose88528
-Ref: -applify89086
-Ref: -on89517
-Ref: -flip90043
-Ref: -const90355
-Ref: -cut90699
-Ref: -not91185
-Ref: -orfn91495
-Ref: -andfn91929
-Ref: -iteratefn92424
-Ref: -fixfn93127
-Ref: -prodfn94696
-Node: Development95765
-Node: Contribute96114
-Node: Changes96862
-Node: Contributors99861
-Node: Index101485
+Node: Installation2422
+Node: Using in a package2989
+Node: Fontification of special variables3350
+Node: Functions4054
+Node: Maps5265
+Ref: -map5560
+Ref: -map-when5901
+Ref: -map-first6484
+Ref: -map-last6962
+Ref: -map-indexed7435
+Ref: -annotate7915
+Ref: -splice8405
+Ref: -splice-list9186
+Ref: -mapcat9648
+Ref: -copy10024
+Node: Sublist selection10228
+Ref: -filter10421
+Ref: -remove10873
+Ref: -remove-first11284
+Ref: -remove-last11811
+Ref: -remove-item12332
+Ref: -non-nil12727
+Ref: -slice12886
+Ref: -take13418
+Ref: -take-last13726
+Ref: -drop14049
+Ref: -drop-last14322
+Ref: -take-while14582
+Ref: -drop-while14932
+Ref: -select-by-indices15288
+Ref: -select-columns15802
+Ref: -select-column16507
+Node: List to list16970
+Ref: -keep17162
+Ref: -concat17665
+Ref: -flatten17962
+Ref: -flatten-n18721
+Ref: -replace19108
+Ref: -replace-first19571
+Ref: -replace-last20068
+Ref: -insert-at20558
+Ref: -replace-at20885
+Ref: -update-at21280
+Ref: -remove-at21771
+Ref: -remove-at-indices22259
+Node: Reductions22841
+Ref: -reduce-from23010
+Ref: -reduce-r-from23776
+Ref: -reduce24543
+Ref: -reduce-r25277
+Ref: -reductions-from26147
+Ref: -reductions-r-from26862
+Ref: -reductions27587
+Ref: -reductions-r28212
+Ref: -count28847
+Ref: -sum29071
+Ref: -running-sum29260
+Ref: -product29553
+Ref: -running-product29762
+Ref: -inits30075
+Ref: -tails30323
+Ref: -common-prefix30570
+Ref: -common-suffix30867
+Ref: -min31164
+Ref: -min-by31390
+Ref: -max31913
+Ref: -max-by32138
+Node: Unfolding32666
+Ref: -iterate32905
+Ref: -unfold33350
+Node: Predicates34158
+Ref: -any?34282
+Ref: -all?34602
+Ref: -none?34932
+Ref: -only-some?35234
+Ref: -contains?35719
+Ref: -same-items?36108
+Ref: -is-prefix?36493
+Ref: -is-suffix?36816
+Ref: -is-infix?37139
+Node: Partitioning37493
+Ref: -split-at37681
+Ref: -split-with37966
+Ref: -split-on38369
+Ref: -split-when39045
+Ref: -separate39685
+Ref: -partition40127
+Ref: -partition-all40579
+Ref: -partition-in-steps41007
+Ref: -partition-all-in-steps41504
+Ref: -partition-by41989
+Ref: -partition-by-header42371
+Ref: -partition-after-pred42975
+Ref: -partition-before-pred43319
+Ref: -partition-before-item43670
+Ref: -partition-after-item43981
+Ref: -group-by44287
+Node: Indexing44724
+Ref: -elem-index44926
+Ref: -elem-indices45321
+Ref: -find-index45704
+Ref: -find-last-index46193
+Ref: -find-indices46697
+Ref: -grade-up47105
+Ref: -grade-down47508
+Node: Set operations47918
+Ref: -union48101
+Ref: -difference48543
+Ref: -intersection48960
+Ref: -powerset49397
+Ref: -permutations49610
+Ref: -distinct49910
+Node: Other list operations50288
+Ref: -rotate50513
+Ref: -repeat50883
+Ref: -cons*51146
+Ref: -snoc51533
+Ref: -interpose51946
+Ref: -interleave52244
+Ref: -zip-with52613
+Ref: -zip53330
+Ref: -zip-lists54162
+Ref: -zip-fill54863
+Ref: -unzip55186
+Ref: -cycle55931
+Ref: -pad56304
+Ref: -table56627
+Ref: -table-flat57417
+Ref: -first58426
+Ref: -some58798
+Ref: -last59107
+Ref: -first-item59441
+Ref: -second-item59857
+Ref: -third-item60137
+Ref: -fourth-item60415
+Ref: -fifth-item60681
+Ref: -last-item60943
+Ref: -butlast61235
+Ref: -sort61482
+Ref: -list61970
+Ref: -fix62301
+Node: Tree operations62841
+Ref: -tree-seq63037
+Ref: -tree-map63895
+Ref: -tree-map-nodes64338
+Ref: -tree-reduce65193
+Ref: -tree-reduce-from66075
+Ref: -tree-mapreduce66676
+Ref: -tree-mapreduce-from67536
+Ref: -clone68822
+Node: Threading macros69150
+Ref: ->69295
+Ref: ->>69787
+Ref: -->70292
+Ref: -as->70853
+Ref: -some->71308
+Ref: -some->>71682
+Ref: -some-->72118
+Node: Binding72589
+Ref: -when-let72801
+Ref: -when-let*73286
+Ref: -if-let73814
+Ref: -if-let*74209
+Ref: -let74826
+Ref: -let*80914
+Ref: -lambda81855
+Ref: -setq82657
+Node: Side-effects83473
+Ref: -each83667
+Ref: -each-while84074
+Ref: -each-indexed84434
+Ref: -each-r84952
+Ref: -each-r-while85385
+Ref: -dotimes85760
+Ref: -doto86063
+Ref: --doto86490
+Node: Destructive operations86765
+Ref: !cons86938
+Ref: !cdr87144
+Node: Function combinators87339
+Ref: -partial87613
+Ref: -rpartial88006
+Ref: -juxt88408
+Ref: -compose88840
+Ref: -applify89398
+Ref: -on89829
+Ref: -flip90355
+Ref: -const90667
+Ref: -cut91011
+Ref: -not91497
+Ref: -orfn91807
+Ref: -andfn92241
+Ref: -iteratefn92736
+Ref: -fixfn93439
+Ref: -prodfn95008
+Node: Development96077
+Node: Contribute96426
+Node: Changes97174
+Node: Contributors100173
+Node: Index101797
 
 End Tag Table
 

--- a/dash.texi
+++ b/dash.texi
@@ -62,7 +62,7 @@ along with this program.  If not, see @uref{http://www.gnu.org/licenses/}.
 Installation
 
 * Using in a package::
-* Syntax highlighting of dash functions::
+* Fontification of special variables::
 
 Functions
 
@@ -114,7 +114,7 @@ Alternatively, you can just dump @verb{~dash.el~} or
 
 @menu
 * Using in a package::
-* Syntax highlighting of dash functions::
+* Fontification of special variables::
 @end menu
 
 @node Using in a package
@@ -132,14 +132,22 @@ Add this to the big comment block at the top:
 ;; Package-Requires: ((dash "2.12.1") (dash-functional "1.2.0") (emacs "24"))
 @end lisp
 
-@node Syntax highlighting of dash functions
-@section Syntax highlighting of dash functions
+@node Fontification of special variables
+@section Fontification of special variables
 
-Font lock of dash functions in emacs lisp buffers is now optional.
-Include this in your emacs settings to get syntax highlighting:
+Font lock of special Dash variables (@code{it}, @code{acc}, etc.@:) in
+Emacs Lisp buffers can optionally be enabled with the autoloaded minor
+mode @code{dash-fontify-mode}.  In older Emacs versions which do not
+dynamically detect macros, the minor mode also fontifies Dash macro
+calls.
+
+To automatically enable the minor mode in all Emacs Lisp buffers, just
+call its autoloaded global counterpart
+@code{global-dash-fontify-mode}, either interactively or from your
+@code{user-init-file}:
 
 @lisp
-(eval-after-load 'dash '(dash-enable-font-lock))
+(global-dash-fontify-mode)
 @end lisp
 
 @node Functions

--- a/readme-template.md
+++ b/readme-template.md
@@ -38,12 +38,20 @@ To get function combinators:
   cons-cell return value, use `-zip-pair` instead.  During the 2.x
   release cycle the new API is available as `-zip-lists`.
 
-## Syntax highlighting of dash functions
+## Fontification of special variables
 
-Font lock of dash functions in emacs lisp buffers is now optional.
-Include this in your emacs settings to get syntax highlighting:
+Font lock of special Dash variables (`it`, `acc`, etc.) in Emacs Lisp
+buffers can optionally be enabled with the autoloaded minor mode
+`dash-fontify-mode`.  In older Emacs versions which do not dynamically
+detect macros, the minor mode also fontifies Dash macro calls.
 
-    (eval-after-load 'dash '(dash-enable-font-lock))
+To automatically enable the minor mode in all Emacs Lisp buffers, just
+call its autoloaded global counterpart `global-dash-fontify-mode`,
+either interactively or from your `user-init-file`:
+
+```el
+(global-dash-fontify-mode)
+```
 
 ## Functions
 


### PR DESCRIPTION
This cleans up the fontification code and makes it less intrusive.  In particular, Dash function calls are no longer fontified, as discussed in #303.

* `dash.el` (`dash`): Fix custom group description.
(`dash--enable-fontlock`): Remove.
(`dash--keywords`): New variable.
(`dash--turn-on-fontify-mode`): New function.
(`dash-fontify-mode-lighter`): New user option.
(`dash-fontify-mode`, `global-dash-fontify-mode`): New autoloaded minor modes replacing `dash-enable-fontlock`, `dash-enable-font-lock`, etc.
(`dash-enable-fontlock`): Update docstring.  Make obsolete in favor of `global-dash-fontify-mode`, which is now called in the `:set` function.
(`dash-enable-font-lock`): Make obsolete alias of `global-dash-fontify-mode`.

* `dash-template.texi` (Syntax highlighting of dash functions):
* `readme-template.md` (Syntax highlighting of dash functions):
Retitle as "Fontification of special variables" for clarity and accuracy and describe `dash-fontify-mode` instead of the now obsolete `dash-enable-font-lock`.

* `README.md`:
* `dash.info`:
* `dash.texi`: Regenerate docs.

Fixes #298, #303.
Closes #310.