### PR TITLE
Add missing indent declaration for ‘-some->’ and siblings

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1536,7 +1536,8 @@ VARIABLE to the result of the first form, and so forth."
 (defmacro -some-> (x &optional form &rest more)
   "When expr is non-nil, thread it through the first form (via `->'),
 and when that result is non-nil, through the next form, etc."
-  (declare (debug ->))
+  (declare (debug ->)
+           (indent 1))
   (if (null form) x
     (let ((result (make-symbol "result")))
       `(-some-> (-when-let (,result ,x)
@@ -1546,7 +1547,8 @@ and when that result is non-nil, through the next form, etc."
 (defmacro -some->> (x &optional form &rest more)
   "When expr is non-nil, thread it through the first form (via `->>'),
 and when that result is non-nil, through the next form, etc."
-  (declare (debug ->))
+  (declare (debug ->)
+           (indent 1))
   (if (null form) x
     (let ((result (make-symbol "result")))
       `(-some->> (-when-let (,result ,x)
@@ -1556,7 +1558,8 @@ and when that result is non-nil, through the next form, etc."
 (defmacro -some--> (x &optional form &rest more)
   "When expr in non-nil, thread it through the first form (via `-->'),
 and when that result is non-nil, through the next form, etc."
-  (declare (debug ->))
+  (declare (debug ->)
+           (indent 1))
   (if (null form) x
     (let ((result (make-symbol "result")))
       `(-some--> (-when-let (,result ,x)


### PR DESCRIPTION
The `->`, `->>`, and `-->` threading macros have short names, and they align
all arguments vertically, including the first one.

While the `-some->`, `-some->>`, and `-some-->` macros have similar
behaviour, they actually have quite long names, resulting in code that
looks like this:

```elisp
  (-some->> '(1 2 3)
            (do-something)
            (and-something-else))
```
Adding a `(declare (indent 1))` declaration for those variants
results in this indentation instead:

```elisp
  (-some->> '(1 2 3)
    (do-something)
    (and-something-else))
```

This is arguably better since the `-some-*` versions of these threading
macros actually treat their first argument a bit special: if the
expression evalutes to nil, the rest won't even run, and this
indentation makes the whole expression look more like a conditional
form.

Fixes #319.