### PR TITLE
regenerate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,9 +1417,9 @@ other value (the body).
 Partition directly after each time `pred` is true on an element of `list`.
 
 ```el
-(-partition-after-pred #'odd? '()) ;; => '()
-(-partition-after-pred #'odd? '(1)) ;; => '((1))
-(-partition-after-pred #'odd? '(0 1)) ;; => '((0 1))
+(-partition-after-pred (function odd?) '()) ;; => '()
+(-partition-after-pred (function odd?) '(1)) ;; => '((1))
+(-partition-after-pred (function odd?) '(0 1)) ;; => '((0 1))
 ```
 
 #### -partition-before-pred `(pred list)`
@@ -1427,9 +1427,9 @@ Partition directly after each time `pred` is true on an element of `list`.
 Partition directly before each time `pred` is true on an element of `list`.
 
 ```el
-(-partition-before-pred #'odd? '()) ;; => '()
-(-partition-before-pred #'odd? '(1)) ;; => '((1))
-(-partition-before-pred #'odd? '(0 1)) ;; => '((0) (1))
+(-partition-before-pred (function odd?) '()) ;; => '()
+(-partition-before-pred (function odd?) '(1)) ;; => '((1))
+(-partition-before-pred (function odd?) '(0 1)) ;; => '((0) (1))
 ```
 
 #### -partition-before-item `(item list)`
@@ -1730,7 +1730,10 @@ If two lists are provided as arguments, return the groupings as a list
 of cons cells. Otherwise, return the groupings as a list of lists.
 
 Please note! This distinction is being removed in an upcoming 3.0
-release of Dash. If you rely on this behavior, use -zip-pair instead.
+release of Dash. If you rely on this behavior, use `-zip-pair` instead,
+which will retain that behaviour in future versions.
+
+Alias: `-zip-pair`
 
 ```el
 (-zip '(1 2 3) '(4 5 6)) ;; => '((1 . 4) (2 . 5) (3 . 6))
@@ -2681,7 +2684,7 @@ expects a list with n items as arguments
 
 ```el
 (-map (-applify '+) '((1 1 1) (1 2 3) (5 5 5))) ;; => '(3 6 15)
-(-map (-applify (lambda (a b c) `(,a (,b (,c))))) '((1 1 1) (1 2 3) (5 5 5))) ;; => '((1 (1 (1))) (1 (2 (3))) (5 (5 (5))))
+(-map (-applify (lambda (a b c) (\` ((\, a) ((\, b) ((\, c))))))) '((1 1 1) (1 2 3) (5 5 5))) ;; => '((1 (1 (1))) (1 (2 (3))) (5 (5 (5))))
 (funcall (-applify '<) '(3 6)) ;; => t
 ```
 

--- a/dash.info
+++ b/dash.info
@@ -1644,8 +1644,11 @@ Other list functions not fit to be classified elsewhere.
      lists.
 
      Please note!  This distinction is being removed in an upcoming
-     3.0 release of Dash.  If you rely on this behavior, use -zip-pair
-     instead.
+     3.0 release of Dash.  If you rely on this behavior, use
+     ‘-zip-pair‘ instead, which will retain that behaviour in future
+     versions.
+
+     Alias: ‘-zip-pair’
 
           (-zip '(1 2 3) '(4 5 6))
               ⇒ '((1 . 4) (2 . 5) (3 . 6))
@@ -2980,7 +2983,7 @@ Index
                                                             (line  56)
 * -as->:                                 Threading macros.  (line  47)
 * -butlast:                              Other list operations.
-                                                            (line 313)
+                                                            (line 316)
 * -clone:                                Tree operations.   (line 123)
 * -common-prefix:                        Reductions.        (line 224)
 * -common-suffix:                        Reductions.        (line 234)
@@ -2997,7 +3000,7 @@ Index
 * -cut:                                  Function combinators.
                                                             (line 106)
 * -cycle:                                Other list operations.
-                                                            (line 141)
+                                                            (line 144)
 * -difference:                           Set operations.    (line  20)
 * -distinct:                             Set operations.    (line  62)
 * -dotimes:                              Side-effects.      (line  61)
@@ -3013,17 +3016,17 @@ Index
 * -elem-index:                           Indexing.          (line   9)
 * -elem-indices:                         Indexing.          (line  21)
 * -fifth-item:                           Other list operations.
-                                                            (line 293)
+                                                            (line 296)
 * -filter:                               Sublist selection. (line   8)
 * -find-index:                           Indexing.          (line  32)
 * -find-indices:                         Indexing.          (line  60)
 * -find-last-index:                      Indexing.          (line  46)
 * -first:                                Other list operations.
-                                                            (line 207)
+                                                            (line 210)
 * -first-item:                           Other list operations.
-                                                            (line 244)
+                                                            (line 247)
 * -fix:                                  Other list operations.
-                                                            (line 349)
+                                                            (line 352)
 * -fixfn:                                Function combinators.
                                                             (line 177)
 * -flatten:                              List to list.      (line  33)
@@ -3031,7 +3034,7 @@ Index
 * -flip:                                 Function combinators.
                                                             (line  81)
 * -fourth-item:                          Other list operations.
-                                                            (line 283)
+                                                            (line 286)
 * -grade-down:                           Indexing.          (line  81)
 * -grade-up:                             Indexing.          (line  71)
 * -group-by:                             Partitioning.      (line 187)
@@ -3055,13 +3058,13 @@ Index
 * -keep:                                 List to list.      (line   8)
 * -lambda:                               Binding.           (line 253)
 * -last:                                 Other list operations.
-                                                            (line 234)
+                                                            (line 237)
 * -last-item:                            Other list operations.
-                                                            (line 303)
+                                                            (line 306)
 * -let:                                  Binding.           (line  66)
 * -let*:                                 Binding.           (line 233)
 * -list:                                 Other list operations.
-                                                            (line 336)
+                                                            (line 339)
 * -map:                                  Maps.              (line  10)
 * -map-first:                            Maps.              (line  38)
 * -map-indexed:                          Maps.              (line  66)
@@ -3082,7 +3085,7 @@ Index
 * -orfn:                                 Function combinators.
                                                             (line 128)
 * -pad:                                  Other list operations.
-                                                            (line 152)
+                                                            (line 155)
 * -partial:                              Function combinators.
                                                             (line   9)
 * -partition:                            Partitioning.      (line  74)
@@ -3128,7 +3131,7 @@ Index
 * -running-sum:                          Reductions.        (line 170)
 * -same-items?:                          Predicates.        (line  72)
 * -second-item:                          Other list operations.
-                                                            (line 259)
+                                                            (line 262)
 * -select-by-indices:                    Sublist selection. (line 169)
 * -select-column:                        Sublist selection. (line 199)
 * -select-columns:                       Sublist selection. (line 180)
@@ -3138,12 +3141,12 @@ Index
 * -snoc:                                 Other list operations.
                                                             (line  44)
 * -some:                                 Other list operations.
-                                                            (line 221)
+                                                            (line 224)
 * -some-->:                              Threading macros.  (line  84)
 * -some->:                               Threading macros.  (line  60)
 * -some->>:                              Threading macros.  (line  72)
 * -sort:                                 Other list operations.
-                                                            (line 323)
+                                                            (line 326)
 * -splice:                               Maps.              (line  91)
 * -splice-list:                          Maps.              (line 111)
 * -split-at:                             Partitioning.      (line   8)
@@ -3152,15 +3155,15 @@ Index
 * -split-with:                           Partitioning.      (line  17)
 * -sum:                                  Reductions.        (line 160)
 * -table:                                Other list operations.
-                                                            (line 163)
+                                                            (line 166)
 * -table-flat:                           Other list operations.
-                                                            (line 182)
+                                                            (line 185)
 * -tails:                                Reductions.        (line 214)
 * -take:                                 Sublist selection. (line 102)
 * -take-last:                            Sublist selection. (line 113)
 * -take-while:                           Sublist selection. (line 147)
 * -third-item:                           Other list operations.
-                                                            (line 271)
+                                                            (line 274)
 * -tree-map:                             Tree operations.   (line  28)
 * -tree-map-nodes:                       Tree operations.   (line  39)
 * -tree-mapreduce:                       Tree operations.   (line  85)
@@ -3171,14 +3174,14 @@ Index
 * -unfold:                               Unfolding.         (line  25)
 * -union:                                Set operations.    (line   8)
 * -unzip:                                Other list operations.
-                                                            (line 124)
+                                                            (line 127)
 * -update-at:                            List to list.      (line 133)
 * -when-let:                             Binding.           (line   9)
 * -when-let*:                            Binding.           (line  23)
 * -zip:                                  Other list operations.
                                                             (line  95)
 * -zip-fill:                             Other list operations.
-                                                            (line 116)
+                                                            (line 119)
 * -zip-with:                             Other list operations.
                                                             (line  79)
 
@@ -3207,184 +3210,184 @@ Ref: -remove10524
 Ref: -remove-first10935
 Ref: -remove-last11462
 Ref: -remove-item11983
-Ref: -non-nil12377
-Ref: -slice12536
-Ref: -take13068
-Ref: -take-last13376
-Ref: -drop13699
-Ref: -drop-last13972
-Ref: -take-while14232
-Ref: -drop-while14582
-Ref: -select-by-indices14938
-Ref: -select-columns15452
-Ref: -select-column16157
-Node: List to list16620
-Ref: -keep16812
-Ref: -concat17315
-Ref: -flatten17612
-Ref: -flatten-n18371
-Ref: -replace18758
-Ref: -replace-first19221
-Ref: -replace-last19717
-Ref: -insert-at20206
-Ref: -replace-at20533
-Ref: -update-at20928
-Ref: -remove-at21419
-Ref: -remove-at-indices21907
-Node: Reductions22489
-Ref: -reduce-from22658
-Ref: -reduce-r-from23424
-Ref: -reduce24191
-Ref: -reduce-r24925
-Ref: -reductions-from25795
-Ref: -reductions-r-from26510
-Ref: -reductions27235
-Ref: -reductions-r27860
-Ref: -count28495
-Ref: -sum28719
-Ref: -running-sum28908
-Ref: -product29201
-Ref: -running-product29410
-Ref: -inits29723
-Ref: -tails29971
-Ref: -common-prefix30218
-Ref: -common-suffix30515
-Ref: -min30812
-Ref: -min-by31038
-Ref: -max31561
-Ref: -max-by31786
-Node: Unfolding32314
-Ref: -iterate32553
-Ref: -unfold32998
-Node: Predicates33806
-Ref: -any?33930
-Ref: -all?34250
-Ref: -none?34580
-Ref: -only-some?34882
-Ref: -contains?35367
-Ref: -same-items?35756
-Ref: -is-prefix?36141
-Ref: -is-suffix?36464
-Ref: -is-infix?36787
-Node: Partitioning37141
-Ref: -split-at37329
-Ref: -split-with37614
-Ref: -split-on38017
-Ref: -split-when38693
-Ref: -separate39333
-Ref: -partition39775
-Ref: -partition-all40227
-Ref: -partition-in-steps40655
-Ref: -partition-all-in-steps41152
-Ref: -partition-by41637
-Ref: -partition-by-header42019
-Ref: -partition-after-pred42623
-Ref: -partition-before-pred42967
-Ref: -partition-before-item43318
-Ref: -partition-after-item43629
-Ref: -group-by43935
-Node: Indexing44372
-Ref: -elem-index44574
-Ref: -elem-indices44969
-Ref: -find-index45352
-Ref: -find-last-index45841
-Ref: -find-indices46345
-Ref: -grade-up46753
-Ref: -grade-down47156
-Node: Set operations47566
-Ref: -union47749
-Ref: -difference48191
-Ref: -intersection48608
-Ref: -powerset49045
-Ref: -permutations49258
-Ref: -distinct49558
-Node: Other list operations49936
-Ref: -rotate50161
-Ref: -repeat50531
-Ref: -cons*50794
-Ref: -snoc51181
-Ref: -interpose51594
-Ref: -interleave51892
-Ref: -zip-with52261
-Ref: -zip52978
-Ref: -zip-fill53784
-Ref: -unzip54107
-Ref: -cycle54641
-Ref: -pad55014
-Ref: -table55337
-Ref: -table-flat56127
-Ref: -first57136
-Ref: -some57508
-Ref: -last57817
-Ref: -first-item58151
-Ref: -second-item58567
-Ref: -third-item58847
-Ref: -fourth-item59125
-Ref: -fifth-item59391
-Ref: -last-item59653
-Ref: -butlast59945
-Ref: -sort60192
-Ref: -list60680
-Ref: -fix61011
-Node: Tree operations61551
-Ref: -tree-seq61747
-Ref: -tree-map62605
-Ref: -tree-map-nodes63048
-Ref: -tree-reduce63903
-Ref: -tree-reduce-from64785
-Ref: -tree-mapreduce65386
-Ref: -tree-mapreduce-from66246
-Ref: -clone67532
-Node: Threading macros67860
-Ref: ->68005
-Ref: ->>68497
-Ref: -->69002
-Ref: -as->69563
-Ref: -some->70018
-Ref: -some->>70392
-Ref: -some-->70828
-Node: Binding71299
-Ref: -when-let71511
-Ref: -when-let*71996
-Ref: -if-let72524
-Ref: -if-let*72919
-Ref: -let73536
-Ref: -let*79624
-Ref: -lambda80565
-Ref: -setq81367
-Node: Side-effects82183
-Ref: -each82377
-Ref: -each-while82784
-Ref: -each-indexed83144
-Ref: -each-r83662
-Ref: -each-r-while84095
-Ref: -dotimes84470
-Ref: -doto84773
-Ref: --doto85200
-Node: Destructive operations85475
-Ref: !cons85648
-Ref: !cdr85854
-Node: Function combinators86049
-Ref: -partial86323
-Ref: -rpartial86718
-Ref: -juxt87120
-Ref: -compose87552
-Ref: -applify88110
-Ref: -on88541
-Ref: -flip89067
-Ref: -const89379
-Ref: -cut89723
-Ref: -not90209
-Ref: -orfn90519
-Ref: -andfn90953
-Ref: -iteratefn91448
-Ref: -fixfn92151
-Ref: -prodfn93720
-Node: Development94789
-Node: Contribute95138
-Node: Changes95886
-Node: Contributors98885
-Node: Index100509
+Ref: -non-nil12378
+Ref: -slice12537
+Ref: -take13069
+Ref: -take-last13377
+Ref: -drop13700
+Ref: -drop-last13973
+Ref: -take-while14233
+Ref: -drop-while14583
+Ref: -select-by-indices14939
+Ref: -select-columns15453
+Ref: -select-column16158
+Node: List to list16621
+Ref: -keep16813
+Ref: -concat17316
+Ref: -flatten17613
+Ref: -flatten-n18372
+Ref: -replace18759
+Ref: -replace-first19222
+Ref: -replace-last19719
+Ref: -insert-at20209
+Ref: -replace-at20536
+Ref: -update-at20931
+Ref: -remove-at21422
+Ref: -remove-at-indices21910
+Node: Reductions22492
+Ref: -reduce-from22661
+Ref: -reduce-r-from23427
+Ref: -reduce24194
+Ref: -reduce-r24928
+Ref: -reductions-from25798
+Ref: -reductions-r-from26513
+Ref: -reductions27238
+Ref: -reductions-r27863
+Ref: -count28498
+Ref: -sum28722
+Ref: -running-sum28911
+Ref: -product29204
+Ref: -running-product29413
+Ref: -inits29726
+Ref: -tails29974
+Ref: -common-prefix30221
+Ref: -common-suffix30518
+Ref: -min30815
+Ref: -min-by31041
+Ref: -max31564
+Ref: -max-by31789
+Node: Unfolding32317
+Ref: -iterate32556
+Ref: -unfold33001
+Node: Predicates33809
+Ref: -any?33933
+Ref: -all?34253
+Ref: -none?34583
+Ref: -only-some?34885
+Ref: -contains?35370
+Ref: -same-items?35759
+Ref: -is-prefix?36144
+Ref: -is-suffix?36467
+Ref: -is-infix?36790
+Node: Partitioning37144
+Ref: -split-at37332
+Ref: -split-with37617
+Ref: -split-on38020
+Ref: -split-when38696
+Ref: -separate39336
+Ref: -partition39778
+Ref: -partition-all40230
+Ref: -partition-in-steps40658
+Ref: -partition-all-in-steps41155
+Ref: -partition-by41640
+Ref: -partition-by-header42022
+Ref: -partition-after-pred42626
+Ref: -partition-before-pred42997
+Ref: -partition-before-item43375
+Ref: -partition-after-item43686
+Ref: -group-by43992
+Node: Indexing44429
+Ref: -elem-index44631
+Ref: -elem-indices45026
+Ref: -find-index45409
+Ref: -find-last-index45898
+Ref: -find-indices46402
+Ref: -grade-up46810
+Ref: -grade-down47213
+Node: Set operations47623
+Ref: -union47806
+Ref: -difference48248
+Ref: -intersection48665
+Ref: -powerset49102
+Ref: -permutations49315
+Ref: -distinct49615
+Node: Other list operations49993
+Ref: -rotate50218
+Ref: -repeat50588
+Ref: -cons*50851
+Ref: -snoc51238
+Ref: -interpose51651
+Ref: -interleave51949
+Ref: -zip-with52318
+Ref: -zip53035
+Ref: -zip-fill53934
+Ref: -unzip54257
+Ref: -cycle54791
+Ref: -pad55164
+Ref: -table55487
+Ref: -table-flat56277
+Ref: -first57286
+Ref: -some57658
+Ref: -last57967
+Ref: -first-item58301
+Ref: -second-item58717
+Ref: -third-item58997
+Ref: -fourth-item59275
+Ref: -fifth-item59541
+Ref: -last-item59803
+Ref: -butlast60095
+Ref: -sort60342
+Ref: -list60830
+Ref: -fix61161
+Node: Tree operations61701
+Ref: -tree-seq61897
+Ref: -tree-map62755
+Ref: -tree-map-nodes63198
+Ref: -tree-reduce64053
+Ref: -tree-reduce-from64935
+Ref: -tree-mapreduce65536
+Ref: -tree-mapreduce-from66396
+Ref: -clone67682
+Node: Threading macros68010
+Ref: ->68155
+Ref: ->>68647
+Ref: -->69152
+Ref: -as->69713
+Ref: -some->70168
+Ref: -some->>70542
+Ref: -some-->70978
+Node: Binding71449
+Ref: -when-let71661
+Ref: -when-let*72146
+Ref: -if-let72674
+Ref: -if-let*73069
+Ref: -let73686
+Ref: -let*79774
+Ref: -lambda80715
+Ref: -setq81517
+Node: Side-effects82333
+Ref: -each82527
+Ref: -each-while82934
+Ref: -each-indexed83294
+Ref: -each-r83812
+Ref: -each-r-while84245
+Ref: -dotimes84620
+Ref: -doto84923
+Ref: --doto85350
+Node: Destructive operations85625
+Ref: !cons85798
+Ref: !cdr86004
+Node: Function combinators86199
+Ref: -partial86473
+Ref: -rpartial86868
+Ref: -juxt87270
+Ref: -compose87702
+Ref: -applify88260
+Ref: -on88707
+Ref: -flip89233
+Ref: -const89545
+Ref: -cut89889
+Ref: -not90375
+Ref: -orfn90685
+Ref: -andfn91119
+Ref: -iteratefn91614
+Ref: -fixfn92317
+Ref: -prodfn93885
+Node: Development94954
+Node: Contribute95303
+Node: Changes96051
+Node: Contributors99050
+Node: Index100674
 
 End Tag Table
 

--- a/dash.texi
+++ b/dash.texi
@@ -2625,7 +2625,10 @@ If two lists are provided as arguments, return the groupings as a list
 of cons cells. Otherwise, return the groupings as a list of lists.
 
 Please note! This distinction is being removed in an upcoming 3.0
-release of Dash. If you rely on this behavior, use -zip-pair instead.
+release of Dash. If you rely on this behavior, use `-zip-pair` instead,
+which will retain that behaviour in future versions.
+
+Alias: @code{-zip-pair}
 
 @example
 @group


### PR DESCRIPTION
i ran `pre-commit.sh` and kept only the relevant changes it made, since a different `emacs`/`makeinfo` version on my machine seems to produce slightly different results, giving weird diffs like this:

```diff
-(-partition-after-pred #'odd? '())
+(-partition-after-pred (function odd?) '())
```

(i skipped all of these weird changes)