### PR TITLE
Apply package-lint/elisp-checkdoc suggestions

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -1,10 +1,12 @@
-;;; dash.el --- A modern list library for Emacs  -*- lexical-binding: t -*-
+;;; dash.el --- A modern list library  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2016 Free Software Foundation, Inc.
 
 ;; Author: Magnar Sveen <magnars@gmail.com>
 ;; Version: 2.16.0
-;; Keywords: lists
+;; Keywords: convenience lists
+;; Package-Requires: ((emacs "24.1"))
+;; URL: https://github.com/magnars/dash.el
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -26,8 +28,8 @@
 ;; See documentation on https://github.com/magnars/dash.el#functions
 ;;
 ;; **Please note** The lexical binding in this file is not utilised at the
-;; moment. We will take full advantage of lexical binding in an upcoming 3.0
-;; release of Dash. In the meantime, we've added the pragma to avoid a bug that
+;; moment.  We will take full advantage of lexical binding in an upcoming 3.0
+;; release of Dash.  In the meantime, we've added the pragma to avoid a bug that
 ;; you can read more about in https://github.com/magnars/dash.el/issues/130.
 ;;
 
@@ -79,8 +81,8 @@ special values."
 
 (defmacro -doto (eval-initial-value &rest forms)
   "Eval a form, then insert that form as the 2nd argument to other forms.
-The EVAL-INITIAL-VALUE form is evaluated once. Its result is
-passed to FORMS, which are then evaluated sequentially. Returns
+The EVAL-INITIAL-VALUE form is evaluated once.  Its result is
+passed to FORMS, which are then evaluated sequentially.  Returns
 the target form."
   (declare (indent 1))
   (let ((retval (make-symbol "value")))
@@ -101,7 +103,7 @@ Note: `it' is not required in each form."
      it))
 
 (defun -each (list fn)
-  "Call FN with every item in LIST. Return nil, used for side-effects only."
+  "Call FN with every item in LIST.  Return nil, used for side-effects only."
   (--each list (funcall fn it)))
 
 (put '-each 'lisp-indent-function 1)
@@ -159,7 +161,7 @@ Return nil, used for side-effects only."
 
 (defun -each-r (list fn)
   "Call FN with every item in LIST in reversed order.
- Return nil, used for side-effects only."
+Return nil, used for side-effects only."
   (--each-r list (funcall fn it)))
 
 (defmacro --each-r-while (list pred &rest body)
@@ -183,7 +185,7 @@ Return nil, used for side-effects only."
   (--each-r-while list (funcall pred it) (funcall fn it)))
 
 (defmacro --dotimes (num &rest body)
-  "Repeatedly executes BODY (presumably for side-effects) with symbol `it' bound to integers from 0 through NUM-1."
+  "Repeatedly execute BODY (presumably for side-effects) with symbol `it' bound to integers from 0 through NUM-1."
   (declare (debug (form body))
            (indent 1))
   (let ((n (make-symbol "num")))
@@ -194,7 +196,7 @@ Return nil, used for side-effects only."
          (setq it (1+ it))))))
 
 (defun -dotimes (num fn)
-  "Repeatedly calls FN (presumably for side-effects) passing in integers from 0 through NUM-1."
+  "Repeatedly call FN (presumably for side-effects) passing in integers from 0 through NUM-1."
   (--dotimes num (funcall fn it)))
 
 (put '-dotimes 'lisp-indent-function 1)
@@ -218,7 +220,7 @@ Return nil, used for side-effects only."
 (defun -reduce-from (fn initial-value list)
   "Return the result of applying FN to INITIAL-VALUE and the
 first item in LIST, then applying FN to that result and the 2nd
-item, etc. If LIST contains no items, return INITIAL-VALUE and
+item, etc.  If LIST contains no items, return INITIAL-VALUE and
 do not call FN.
 
 In the anaphoric form `--reduce-from', the accumulated value is
@@ -238,9 +240,9 @@ See also: `-reduce', `-reduce-r'"
 
 (defun -reduce (fn list)
   "Return the result of applying FN to the first 2 items in LIST,
-then applying FN to that result and the 3rd item, etc. If LIST
+then applying FN to that result and the 3rd item, etc.  If LIST
 contains no items, return the result of calling FN with no
-arguments. If LIST contains a single item, return that item
+arguments.  If LIST contains a single item, return that item
 and do not call FN.
 
 In the anaphoric form `--reduce', the accumulated value is
@@ -258,7 +260,7 @@ See also: `-reduce-from', `-reduce-r'"
 
 (defun -reduce-r-from (fn initial-value list)
   "Replace conses with FN, nil with INITIAL-VALUE and evaluate
-the resulting expression. If LIST is empty, INITIAL-VALUE is
+the resulting expression.  If LIST is empty, INITIAL-VALUE is
 returned and FN is not called.
 
 Note: this function works the same as `-reduce-from' but the
@@ -274,8 +276,8 @@ See also: `-reduce-r', `-reduce'"
 
 (defun -reduce-r (fn list)
   "Replace conses with FN and evaluate the resulting expression.
-The final nil is ignored. If LIST contains no items, return the
-result of calling FN with no arguments. If LIST contains a single
+The final nil is ignored.  If LIST contains no items, return the
+result of calling FN with no arguments.  If LIST contains a single
 item, return that item and do not call FN.
 
 The first argument of FN is the new item, the second is the
@@ -455,9 +457,10 @@ See also: `-each-indexed'."
        (nreverse ,r))))
 
 (defun -map-when (pred rep list)
-  "Return a new list where the elements in LIST that do not match the PRED function
-are unchanged, and where the elements in LIST that do match the PRED function are mapped
-through the REP function.
+  "Return a new list where the elements in LIST that do not match
+the PRED function are unchanged, and where the elements in LIST
+that do match the PRED function are mapped through the REP
+function.
 
 Alias: `-replace-where'
 
@@ -533,7 +536,7 @@ Thus function FN should return a list."
 (defun -flatten (l)
   "Take a nested list L and return its contents as a single, flat list.
 
-Note that because `nil' represents a list of zero elements (an
+Note that because nil represents a list of zero elements (an
 empty list), any mention of nil in L will disappear after
 flattening.  If you need to preserve nils, consider `-flatten-n'
 or map them to some unique symbol and then map them back.
@@ -1050,7 +1053,7 @@ This function can be thought of as a generalization of
 (defun ---partition-all-in-steps-reversed (n step list)
   "Private: Used by -partition-all-in-steps and -partition-in-steps."
   (when (< step 1)
-    (error "Step must be a positive number, or you're looking at some juicy infinite loops."))
+    (error "Step must be a positive number, or you're looking at some juicy infinite loops"))
   (let ((result nil))
     (while list
       (!cons (-take n list) result)
@@ -1149,10 +1152,10 @@ those items are discarded."
            (nreverse ,r))))))
 
 (defun -partition-by-header (fn list)
-  "Apply FN to the first item in LIST. That is the header
-value. Apply FN to each item in LIST, splitting it each time FN
-returns the header value, but only after seeing at least one
-other value (the body)."
+  "Apply FN to the first item in LIST.
+That is the header value.  Apply FN to each item in LIST,
+splitting it each time FN returns the header value, but only
+after seeing at least one other value (the body)."
   (--partition-by-header (funcall fn it) list))
 
 (defun -partition-after-pred (pred list)
@@ -1254,25 +1257,26 @@ The elements in list1 are bound as symbol `it', the elements in list2 as symbol 
        (nreverse ,r))))
 
 (defun -zip-with (fn list1 list2)
-  "Zip the two lists LIST1 and LIST2 using a function FN.  This
-function is applied pairwise taking as first argument element of
-LIST1 and as second argument element of LIST2 at corresponding
-position.
+  "Zip the two lists LIST1 and LIST2 using a function FN.
+This function is applied pairwise taking as first argument
+element of LIST1 and as second argument element of LIST2 at
+corresponding position.
 
 The anaphoric form `--zip-with' binds the elements from LIST1 as symbol `it',
 and the elements from LIST2 as symbol `other'."
   (--zip-with (funcall fn it other) list1 list2))
 
 (defun -zip (&rest lists)
-  "Zip LISTS together.  Group the head of each list, followed by the
-second elements of each list, and so on. The lengths of the returned
-groupings are equal to the length of the shortest input list.
+  "Zip LISTS together.
+Group the head of each list, followed by the second elements of
+each list, and so on.  The lengths of the returned groupings are
+equal to the length of the shortest input list.
 
 If two lists are provided as arguments, return the groupings as a list
-of cons cells. Otherwise, return the groupings as a list of lists.
+of cons cells.  Otherwise, return the groupings as a list of lists.
 
 Please note! This distinction is being removed in an upcoming 3.0
-release of Dash. If you rely on this behavior, use `-zip-pair` instead,
+release of Dash.  If you rely on this behavior, use `-zip-pair` instead,
 which will retain that behaviour in future versions.
 
 Alias: `-zip-pair'"
@@ -1292,9 +1296,9 @@ Alias: `-zip-pair'"
 (defalias '-zip-pair '-zip)
 
 (defun -zip-fill (fill-value &rest lists)
-  "Zip LISTS, with FILL-VALUE padded onto the shorter lists. The
-lengths of the returned groupings are equal to the length of the
-longest input list."
+  "Zip LISTS, with FILL-VALUE padded onto the shorter lists.
+The lengths of the returned groupings are equal to the length of
+the longest input list."
   (declare (pure t) (side-effect-free t))
   (apply '-zip (apply '-pad (cons fill-value lists))))
 
@@ -1319,7 +1323,7 @@ elements and repeat from the beginning."
     (nconc newlist newlist)))
 
 (defun -pad (fill-value &rest lists)
-  "Appends FILL-VALUE to the end of each list in LISTS such that they
+  "Append FILL-VALUE to the end of each list in LISTS such that they
 will all have the same length."
   (let* ((annotations (-annotate 'length lists))
          (n (-max (-map 'car annotations))))
@@ -1487,10 +1491,10 @@ See also: `-select-columns', `-select-by-indices'"
   (--mapcat (-select-by-indices (list column) it) table))
 
 (defmacro -> (x &optional form &rest more)
-  "Thread the expr through the forms. Insert X as the second item
-in the first form, making a list of it if it is not a list
-already. If there are more forms, insert the first form as the
-second item in second form, etc."
+  "Thread the expr through the forms.
+Insert X as the second item in the first form, making a list of
+it if it is not a list already.  If there are more forms, insert
+the first form as the second item in second form, etc."
   (declare (debug (form &rest [&or symbolp (sexp &rest form)])))
   (cond
    ((null form) x)
@@ -1500,10 +1504,10 @@ second item in second form, etc."
    (:else `(-> (-> ,x ,form) ,@more))))
 
 (defmacro ->> (x &optional form &rest more)
-  "Thread the expr through the forms. Insert X as the last item
-in the first form, making a list of it if it is not a list
-already. If there are more forms, insert the first form as the
-last item in second form, etc."
+  "Thread the expr through the forms.
+Insert X as the last item in the first form, making a list of it
+if it is not a list already.  If there are more forms, insert the
+first form as the last item in second form, etc."
   (declare (debug ->))
   (cond
    ((null form) x)
@@ -1669,7 +1673,7 @@ MATCH-FORM is either a symbol, which gets bound to the respective
 value in source or another match form which gets destructured
 recursively.
 
-If the cdr of last cons cell in the list is `nil', matching stops
+If the cdr of last cons cell in the list is nil, matching stops
 there.
 
 SOURCE is a proper or improper list."
@@ -2203,7 +2207,7 @@ multiple assignments it does not cause unexpected side effects.
 
 (defmacro -if-let* (vars-vals then &rest else)
   "If all VALS evaluate to true, bind them to their corresponding
-VARS and do THEN, otherwise do ELSE. VARS-VALS should be a list
+VARS and do THEN, otherwise do ELSE.  VARS-VALS should be a list
 of (VAR VAL) pairs.
 
 Note: binding is done according to `-let*'.  VALS are evaluated
@@ -2240,7 +2244,7 @@ otherwise do ELSE."
 
 (defmacro -when-let* (vars-vals &rest body)
   "If all VALS evaluate to true, bind them to their corresponding
-VARS and execute body. VARS-VALS should be a list of (VAR VAL)
+VARS and execute body.  VARS-VALS should be a list of (VAR VAL)
 pairs.
 
 Note: binding is done according to `-let*'.  VALS are evaluated
@@ -2261,8 +2265,7 @@ Note: binding is done according to `-let'.
   `(-if-let ,var-val (progn ,@body)))
 
 (defmacro --when-let (val &rest body)
-  "If VAL evaluates to non-nil, bind it to symbol `it' and
-execute body."
+  "If VAL evaluate to non-nil, bind it to symbol `it' and execute body."
   (declare (debug (form body))
            (indent 1))
   `(--if-let ,val (progn ,@body)))
@@ -2354,7 +2357,7 @@ or with `-compare-fn' if that's non-nil."
     res))
 
 (defun -tails (list)
-  "Return all suffixes of LIST"
+  "Return all suffixes of LIST."
   (-reductions-r-from 'cons nil list))
 
 (defun -common-prefix (&rest lists)
@@ -2390,7 +2393,7 @@ Alias: `-contains-p'"
 (defalias '-contains-p '-contains?)
 
 (defun -same-items? (list list2)
-  "Return true if LIST and LIST2 has the same items.
+  "Return non-nil if LIST and LIST2 has the same items.
 
 The order of the elements in the lists does not matter.
 
@@ -2568,7 +2571,7 @@ This is \"dual\" operation to `-reduce-r': while -reduce-r
 consumes a list to produce a single value, `-unfold' takes a
 seed value and builds a (potentially infinite!) list.
 
-FUN should return `nil' to stop the generating process, or a
+FUN should return nil to stop the generating process, or a
 cons (A . B), where A will be prepended to the result and B is
 the new seed."
   (let ((last (funcall fun seed)) r)
@@ -2616,7 +2619,7 @@ If elements of TREE are lists themselves, apply FN recursively to
 elements of these nested lists.
 
 Then reduce the resulting lists using FOLDER and initial value
-INIT-VALUE. See `-reduce-r-from'.
+INIT-VALUE.  See `-reduce-r-from'.
 
 This is the same as calling `-tree-reduce-from' after `-tree-map'
 but is twice as fast as it only traverse the structure once."
@@ -2638,7 +2641,7 @@ If elements of TREE are lists themselves, apply FN recursively to
 elements of these nested lists.
 
 Then reduce the resulting lists using FOLDER and initial value
-INIT-VALUE. See `-reduce-r-from'.
+INIT-VALUE.  See `-reduce-r-from'.
 
 This is the same as calling `-tree-reduce' after `-tree-map'
 but is twice as fast as it only traverse the structure once."


### PR DESCRIPTION
Hi! I found this package and found many package-lint/elisp-checkdoc errors.
So I fix them to fix easy as my first contribution step.

### before
470 erros/warnings
```emacs-lisp
 dash.el     1   1 warning         Including "Emacs" in the package summary is usually redundant. (emacs-lisp-package)
 dash.el     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 dash.el     1  54 warning         You should depend on (emacs "24") if you need lexical-binding. (emacs-lisp-package)
 dash.el     7   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 dash.el    29     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el    30     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el    40  15 warning         Replace deprecated `cl' with `cl-lib'.  The `cl-libify' package can help with this. (emacs-lisp-package)
 dash.el    48     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dash.el    53     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el    59   1 error           "!cons" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    63   1 error           "!cdr" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    67   1 error           "--each" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    68     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el    80   1 error           "-doto" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    82     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el    83     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el    95   1 error           "--doto" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    96     warning         Argument ‘eval-initial-value’ should appear (as EVAL-INITIAL-VALUE) in the doc string (emacs-lisp-checkdoc)
 dash.el   103   1 error           "-each" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   104     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   109   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   111   1 error           "-each-indexed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   112     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   120   1 error           "--each-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   121     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   135   1 error           "-each-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   142   1 error           "--each-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   143     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   160   1 error           "-each-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   161     warning         Second line should not have indentation (emacs-lisp-checkdoc)
 dash.el   165   1 error           "--each-r-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   166     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   180   1 error           "-each-r-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   185   1 error           "--dotimes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   186     warning         Argument ‘num’ should appear (as NUM) in the doc string (emacs-lisp-checkdoc)
 dash.el   186     warning         Probably "executes" should be imperative "execute" (emacs-lisp-checkdoc)
 dash.el   196   1 error           "-dotimes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   197     warning         Argument ‘num’ should appear (as NUM) in the doc string (emacs-lisp-checkdoc)
 dash.el   197     warning         Probably "calls" should be imperative "call" (emacs-lisp-checkdoc)
 dash.el   202   1 error           "-map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   206   1 error           "--map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   207     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   211   1 error           "--reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   212     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   218   1 error           "-reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   219     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   221     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   230   1 error           "--reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   231     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   239   1 error           "-reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   240     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   241     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   243     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   254   1 error           "--reduce-r-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   255     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   259   1 error           "-reduce-r-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   260     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   261     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   270   1 error           "--reduce-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   271     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   275   1 error           "-reduce-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   277     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   278     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el   292   1 error           "-reductions-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   293     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   300   1 error           "-reductions" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   301     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   308   1 error           "-reductions-r-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   309     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   316   1 error           "-reductions-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   317     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   328   1 error           "--filter" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   329     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   338   1 error           "-filter" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   339     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   339     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el   346   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   347   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   349   1 error           "--remove" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   350     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   356   1 error           "-remove" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   357     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el   364   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   365   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   367   1 error           "-remove-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   368     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   381   1 error           "--remove-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   382     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   386   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   387   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   389   1 error           "-remove-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   390     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   397   1 error           "--remove-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   398     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   402   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   403   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   405   1 error           "-remove-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   412   1 error           "--keep" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   413     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   421   1 error           "-keep" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   427   1 error           "-non-nil" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   432   1 error           "--map-indexed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   433     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   441   1 error           "-map-indexed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   442     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   449   1 error           "--map-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   450     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   457   1 error           "-map-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   458     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   458     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   467   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   468   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   470   1 error           "-map-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   471     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   482   1 error           "--map-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   483     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   486   1 error           "-map-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   487     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   492   1 error           "--map-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   493     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   496   1 error           "-replace" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   505   1 error           "-replace-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   514   1 error           "-replace-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   523   1 error           "--mapcat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   524     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   528   1 error           "-mapcat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   533   1 error           "-flatten" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   536     warning         Symbols t and nil should not appear in single quotes (emacs-lisp-checkdoc)
 dash.el   550   1 error           "--iterate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   551     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   555   1 error           "-flatten-n" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   562   1 error           "-concat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   567   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   572   1 error           "-splice" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   590   1 error           "--splice" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   591     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   594   1 error           "-splice-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   600   1 error           "--splice-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   601     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   604   1 error           "-cons*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   613   1 error           "-snoc" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   614     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   621   1 error           "--first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   622     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   630   1 error           "-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   638   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   639   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   641   1 error           "--some" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   642     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   650   1 error           "-some" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   656   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   657   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   659   1 error           "--last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   660     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   668   1 error           "-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   672   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   684   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   691   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   701   1 error           "-fourth-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   708   1 error           "-fifth-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   715   1 error           "-last-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   726   1 error           "-last-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   728   1 error           "-butlast" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   729     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   734   1 error           "--count" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   735     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   742   1 error           "-count" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   746   1 error           "---truthy?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   747     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dash.el   750   1 error           "--any?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   751     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   755   1 error           "-any?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   761   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   762   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   763   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   764   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   765   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   766   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   768   1 error           "--all?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   769     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   776   1 error           "-all?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   782   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   783   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   784   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   785   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   786   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   787   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   789   1 error           "--none?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   790     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   794   1 error           "-none?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   800   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   801   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   803   1 error           "--only-some?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   804     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   813   1 error           "-only-some?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   814     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   814     warning         Probably "matches" should be imperative "match" (emacs-lisp-checkdoc)
 dash.el   820   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   821   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   823   1 error           "-slice" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   850   1 error           "-take" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   851     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   862   1 error           "-take-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   869   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   876   1 error           "-drop-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   884   1 error           "--take-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   885     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   892   1 error           "-take-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   893     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el   896   1 error           "--drop-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   897     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   905   1 error           "-drop-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   906     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el   909   1 error           "-split-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   919   1 error           "-rotate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   929   1 error           "-insert-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   937   1 error           "-replace-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   945   1 error           "-update-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   946     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   946     warning         Argument ‘func’ should appear (as FUNC) in the doc string (emacs-lisp-checkdoc)
 dash.el   952   1 error           "--update-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   953     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el   957   1 error           "-remove-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   964   1 error           "-remove-at-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   965     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   981   1 error           "--split-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   982     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   998   1 error           "-split-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1002   1 error           "-split-on" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1014   1 error           "--split-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1015     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1019   1 error           "-split-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1020     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el  1037   1 error           "--separate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1038     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1046   1 error           "-separate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1050   1 error           "---partition-all-in-steps-reversed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1051     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el  1053     warning         Error messages should *not* end with a period (emacs-lisp-checkdoc)
 dash.el  1060   1 error           "-partition-all-in-steps" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1061     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  1066   1 error           "-partition-in-steps" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1067     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  1067     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el  1076   1 error           "-partition-all" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1082   1 error           "-partition" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1083     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el  1089   1 error           "--partition-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1090     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1116   1 error           "-partition-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1117     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el  1120   1 error           "--partition-by-header" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1121     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1151   1 error           "-partition-by-header" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1152     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1152     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1153     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1158   1 error           "-partition-after-pred" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1173   1 error           "-partition-before-pred" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1178   1 error           "-partition-after-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1183   1 error           "-partition-before-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1188   1 error           "--group-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1189     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1210   1 error           "-group-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1211     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1215   1 error           "-interpose" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1227   1 error           "-interleave" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1228     warning         Argument ‘lists’ should appear (as LISTS) in the doc string (emacs-lisp-checkdoc)
 dash.el  1237   1 error           "--zip-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1238     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1256   1 error           "-zip-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1257     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1266   1 error           "-zip" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1267     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1268     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1272     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1275     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1292   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  1294   1 error           "-zip-fill" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1295     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1295     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1301   1 error           "-unzip" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1314   1 error           "-cycle" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1315     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1321   1 error           "-pad" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1322     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1322     warning         Probably "Appends" should be imperative "Append" (emacs-lisp-checkdoc)
 dash.el  1328   1 error           "-annotate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1329     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1333   1 error           "--annotate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1334     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1339     warning         Argument ‘lists’ should appear (as LISTS) in the doc string (emacs-lisp-checkdoc)
 dash.el  1353   1 error           "-table" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1374   1 error           "-table-flat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1400   1 error           "-partial" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1401     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1407   1 error           "-elem-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1408     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1414   1 error           "-elem-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1415     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1420   1 error           "-find-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1421     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1425   1 error           "--find-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1426     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1430   1 error           "-find-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1431     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1438   1 error           "--find-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1439     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1443   1 error           "-find-last-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1444     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1451   1 error           "--find-last-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1452     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1455   1 error           "-select-by-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1456     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1464   1 error           "-select-columns" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1477   1 error           "-select-column" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1489   1 error           "->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1490     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1490     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1490     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1492     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1502   1 error           "->>" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1503     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1503     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1503     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1505     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  1515   1 error           "-->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1524   1 error           "-as->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1539   1 error           "-some->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1540     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1540     warning         Argument ‘x’ should appear (as X) in the doc string (emacs-lisp-checkdoc)
 dash.el  1550   1 error           "-some->>" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1551     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1551     warning         Argument ‘x’ should appear (as X) in the doc string (emacs-lisp-checkdoc)
 dash.el  1561   1 error           "-some-->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1562     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1562     warning         Argument ‘x’ should appear (as X) in the doc string (emacs-lisp-checkdoc)
 dash.el  1572   1 error           "-grade-up" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1573     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1582   1 error           "-grade-down" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1583     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1603     warning         Probably "starts" should be imperative "start" (emacs-lisp-checkdoc)
 dash.el  1608     warning         Argument ‘skip-cdr’ should appear (as SKIP-CDR) in the doc string (emacs-lisp-checkdoc)
 dash.el  1617     warning         Argument ‘skip-cdr’ should appear (as SKIP-CDR) in the doc string (emacs-lisp-checkdoc)
 dash.el  1627     warning         Argument ‘skip-cdr’ should appear (as SKIP-CDR) in the doc string (emacs-lisp-checkdoc)
 dash.el  1637     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1665     warning         Argument ‘props’ should appear (as PROPS) in the doc string (emacs-lisp-checkdoc)
 dash.el  1672     warning         Symbols t and nil should not appear in single quotes (emacs-lisp-checkdoc)
 dash.el  1710     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1810     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1824   1 error           `dash-expand:&hash' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1828   1 error           `dash-expand:&plist' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1832   1 error           `dash-expand:&alist' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1836   1 error           `dash-expand:&hash?' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1871     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1924   1 error           "-let*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1943   1 error           "-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2117   1 error           "-lambda" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2118     warning         Probably "executes" should be imperative "execute" (emacs-lisp-checkdoc)
 dash.el  2150   1 error           "-setq" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2151     warning         Argument ‘forms’ should appear (as FORMS) in the doc string (emacs-lisp-checkdoc)
 dash.el  2204   1 error           "-if-let*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2205     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2206     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  2223   1 error           "-if-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2224     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2224     warning         Argument ‘var-val’ should appear (as VAR-VAL) in the doc string (emacs-lisp-checkdoc)
 dash.el  2224     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2234   1 error           "--if-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2235     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2235     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2241   1 error           "-when-let*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2242     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2242     warning         Argument ‘body’ should appear (as BODY) in the doc string (emacs-lisp-checkdoc)
 dash.el  2243     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  2253   1 error           "-when-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2254     warning         Argument ‘var-val’ should appear (as VAR-VAL) in the doc string (emacs-lisp-checkdoc)
 dash.el  2254     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2263   1 error           "--when-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2264     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2264     warning         Argument ‘body’ should appear (as BODY) in the doc string (emacs-lisp-checkdoc)
 dash.el  2264     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2270   1 error           "-compare-fn" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2276   1 error           "-distinct" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2277     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el  2299   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2301   1 error           "-union" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2302     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  2320   1 error           "-intersection" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2321     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  2326   1 error           "-difference" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2332   1 error           "-powerset" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2339   1 error           "-permutations" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2348   1 error           "-inits" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2356   1 error           "-tails" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2357     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 dash.el  2360   1 error           "-common-prefix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2366   1 error           "-common-suffix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2370   1 error           "-contains?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2371     warning         Probably "contains" should be imperative "contain" (emacs-lisp-checkdoc)
 dash.el  2390   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2392   1 error           "-same-items?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2393     warning         "true" should usually be "non-nil" (emacs-lisp-checkdoc)
 dash.el  2404   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2406   1 error           "-is-prefix?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2415   1 error           "-is-suffix?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2422   1 error           "-is-infix?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2435   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2436   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2437   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2439   1 error           "-sort" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2446   1 error           "--sort" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2447     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2451   1 error           "-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2460   1 error           "-repeat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2468   1 error           "-sum" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2473   1 error           "-running-sum" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2482   1 error           "-product" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2487   1 error           "-running-product" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2496   1 error           "-max" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2501   1 error           "-min" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2506   1 error           "-max-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2507     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2514   1 error           "-min-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2515     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2522   1 error           "--max-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2523     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2529   1 error           "--min-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2530     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2536   1 error           "-iterate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2550   1 error           "-fix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2560   1 error           "--fix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2561     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2564   1 error           "-unfold" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2571     warning         Symbols t and nil should not appear in single quotes (emacs-lisp-checkdoc)
 dash.el  2580   1 error           "--unfold" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2581     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2585   1 error           "-cons-pair?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2594   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2596   1 error           "-cons-to-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2597     warning         Argument ‘con’ should appear (as CON) in the doc string (emacs-lisp-checkdoc)
 dash.el  2601   1 error           "-value-to-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2602     warning         Argument ‘val’ should appear (as VAL) in the doc string (emacs-lisp-checkdoc)
 dash.el  2613   1 error           "-tree-mapreduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2619     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  2630   1 error           "--tree-mapreduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2631     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2635   1 error           "-tree-mapreduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2641     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 dash.el  2652   1 error           "--tree-mapreduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2653     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2657   1 error           "-tree-map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2666   1 error           "--tree-map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2667     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2671   1 error           "-tree-reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2687   1 error           "--tree-reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2688     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2692   1 error           "-tree-reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2707   1 error           "--tree-reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2708     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2712   1 error           "-tree-map-nodes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2725   1 error           "--tree-map-nodes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2726     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el  2729   1 error           "-tree-seq" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2744   1 error           "--tree-seq" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2745     warning         Argument ‘branch’ should appear (as BRANCH) in the doc string (emacs-lisp-checkdoc)
 dash.el  2748   1 error           "-clone" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2758   4 warning         `eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
 dash.el  3030  30 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 dash.el  3036  35 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
```

### after
417 errors/warnings
```emacs-lisp
 dash.el    42  15 warning         Replace deprecated `cl' with `cl-lib'.  The `cl-libify' package can help with this. (emacs-lisp-package)
 dash.el    50     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dash.el    55     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el    61   1 error           "!cons" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    65   1 error           "!cdr" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    69   1 error           "--each" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    70     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el    82   1 error           "-doto" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    97   1 error           "--doto" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el    98     warning         Argument ‘eval-initial-value’ should appear (as EVAL-INITIAL-VALUE) in the doc string (emacs-lisp-checkdoc)
 dash.el   105   1 error           "-each" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   111   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   113   1 error           "-each-indexed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   114     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   122   1 error           "--each-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   123     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   137   1 error           "-each-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   144   1 error           "--each-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   145     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   162   1 error           "-each-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   167   1 error           "--each-r-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   168     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   182   1 error           "-each-r-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   187   1 error           "--dotimes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   188     warning         Argument ‘num’ should appear (as NUM) in the doc string (emacs-lisp-checkdoc)
 dash.el   198   1 error           "-dotimes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   199     warning         Argument ‘num’ should appear (as NUM) in the doc string (emacs-lisp-checkdoc)
 dash.el   204   1 error           "-map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   208   1 error           "--map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   209     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   213   1 error           "--reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   214     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   220   1 error           "-reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   221     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   232   1 error           "--reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   233     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   241   1 error           "-reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   242     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   256   1 error           "--reduce-r-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   257     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   261   1 error           "-reduce-r-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   262     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   272   1 error           "--reduce-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   273     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   277   1 error           "-reduce-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   294   1 error           "-reductions-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   295     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   302   1 error           "-reductions" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   303     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   310   1 error           "-reductions-r-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   311     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   318   1 error           "-reductions-r" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   319     warning         Argument ‘fn’ should appear (as FN) in the doc string (emacs-lisp-checkdoc)
 dash.el   330   1 error           "--filter" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   331     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   340   1 error           "-filter" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   341     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   341     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el   348   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   349   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   351   1 error           "--remove" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   352     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   358   1 error           "-remove" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   366   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   367   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   369   1 error           "-remove-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   370     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   383   1 error           "--remove-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   384     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   388   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   389   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   391   1 error           "-remove-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   392     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   399   1 error           "--remove-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   400     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   404   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   405   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   407   1 error           "-remove-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   414   1 error           "--keep" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   415     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   423   1 error           "-keep" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   429   1 error           "-non-nil" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   434   1 error           "--map-indexed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   435     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   443   1 error           "-map-indexed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   444     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   451   1 error           "--map-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   452     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   459   1 error           "-map-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   460     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   470   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   471   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   473   1 error           "-map-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   474     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   485   1 error           "--map-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   486     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   489   1 error           "-map-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   490     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   495   1 error           "--map-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   496     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   499   1 error           "-replace" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   508   1 error           "-replace-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   517   1 error           "-replace-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   526   1 error           "--mapcat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   527     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   531   1 error           "-mapcat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   536   1 error           "-flatten" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   553   1 error           "--iterate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   554     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   558   1 error           "-flatten-n" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   565   1 error           "-concat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   570   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   575   1 error           "-splice" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   593   1 error           "--splice" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   594     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   597   1 error           "-splice-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   603   1 error           "--splice-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   604     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   607   1 error           "-cons*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   616   1 error           "-snoc" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   617     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   624   1 error           "--first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   625     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   633   1 error           "-first" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   641   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   642   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   644   1 error           "--some" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   645     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   653   1 error           "-some" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   659   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   660   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   662   1 error           "--last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   663     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   671   1 error           "-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   675   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   687   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   694   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   704   1 error           "-fourth-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   711   1 error           "-fifth-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   718   1 error           "-last-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   729   1 error           "-last-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   731   1 error           "-butlast" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   732     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el   737   1 error           "--count" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   738     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el   745   1 error           "-count" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   749   1 error           "---truthy?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   750     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 dash.el   753   1 error           "--any?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   754     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   758   1 error           "-any?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   764   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   765   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   766   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   767   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   768   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   769   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   771   1 error           "--all?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   772     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   779   1 error           "-all?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   785   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   786   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   787   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   788   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   789   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   790   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   792   1 error           "--none?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   793     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   797   1 error           "-none?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   803   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   804   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   806   1 error           "--only-some?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   807     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   816   1 error           "-only-some?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   817     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   817     warning         Probably "matches" should be imperative "match" (emacs-lisp-checkdoc)
 dash.el   823   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   824   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   826   1 error           "-slice" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   853   1 error           "-take" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   854     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   865   1 error           "-take-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   872   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el   879   1 error           "-drop-last" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   887   1 error           "--take-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   888     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   895   1 error           "-take-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   896     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el   899   1 error           "--drop-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   900     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el   908   1 error           "-drop-while" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   912   1 error           "-split-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   922   1 error           "-rotate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   932   1 error           "-insert-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   940   1 error           "-replace-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   948   1 error           "-update-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   949     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el   949     warning         Argument ‘func’ should appear (as FUNC) in the doc string (emacs-lisp-checkdoc)
 dash.el   955   1 error           "--update-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   956     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el   960   1 error           "-remove-at" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   967   1 error           "-remove-at-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   968     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el   984   1 error           "--split-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el   985     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el  1001   1 error           "-split-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1005   1 error           "-split-on" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1017   1 error           "--split-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1018     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1022   1 error           "-split-when" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1023     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el  1040   1 error           "--separate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1041     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1049   1 error           "-separate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1053   1 error           "---partition-all-in-steps-reversed" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1054     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el  1063   1 error           "-partition-all-in-steps" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1064     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  1069   1 error           "-partition-in-steps" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1070     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  1070     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el  1079   1 error           "-partition-all" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1085   1 error           "-partition" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1086     warning         Argument ‘n’ should appear (as N) in the doc string (emacs-lisp-checkdoc)
 dash.el  1092   1 error           "--partition-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1093     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1119   1 error           "-partition-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1120     warning         Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
 dash.el  1123   1 error           "--partition-by-header" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1124     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1154   1 error           "-partition-by-header" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1161   1 error           "-partition-after-pred" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1176   1 error           "-partition-before-pred" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1181   1 error           "-partition-after-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1186   1 error           "-partition-before-item" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1191   1 error           "--group-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1192     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1213   1 error           "-group-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1214     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1218   1 error           "-interpose" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1230   1 error           "-interleave" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1231     warning         Argument ‘lists’ should appear (as LISTS) in the doc string (emacs-lisp-checkdoc)
 dash.el  1240   1 error           "--zip-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1241     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1259   1 error           "-zip-with" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1269   1 error           "-zip" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1296   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  1298   1 error           "-zip-fill" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1305   1 error           "-unzip" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1318   1 error           "-cycle" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1319     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1325   1 error           "-pad" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1326     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1332   1 error           "-annotate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1333     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1337   1 error           "--annotate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1338     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1343     warning         Argument ‘lists’ should appear (as LISTS) in the doc string (emacs-lisp-checkdoc)
 dash.el  1357   1 error           "-table" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1378   1 error           "-table-flat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1404   1 error           "-partial" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1405     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1411   1 error           "-elem-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1412     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1418   1 error           "-elem-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1419     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1424   1 error           "-find-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1425     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1429   1 error           "--find-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1430     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1434   1 error           "-find-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1435     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1442   1 error           "--find-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1443     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1447   1 error           "-find-last-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1448     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1455   1 error           "--find-last-index" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1456     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1459   1 error           "-select-by-indices" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1460     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1468   1 error           "-select-columns" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1481   1 error           "-select-column" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1493   1 error           "->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1494     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1506   1 error           "->>" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1507     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1519   1 error           "-->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1528   1 error           "-as->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1543   1 error           "-some->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1544     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1544     warning         Argument ‘x’ should appear (as X) in the doc string (emacs-lisp-checkdoc)
 dash.el  1554   1 error           "-some->>" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1555     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1555     warning         Argument ‘x’ should appear (as X) in the doc string (emacs-lisp-checkdoc)
 dash.el  1565   1 error           "-some-->" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1566     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1566     warning         Argument ‘x’ should appear (as X) in the doc string (emacs-lisp-checkdoc)
 dash.el  1576   1 error           "-grade-up" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1577     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1586   1 error           "-grade-down" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1587     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  1612     warning         Argument ‘skip-cdr’ should appear (as SKIP-CDR) in the doc string (emacs-lisp-checkdoc)
 dash.el  1621     warning         Argument ‘skip-cdr’ should appear (as SKIP-CDR) in the doc string (emacs-lisp-checkdoc)
 dash.el  1631     warning         Argument ‘skip-cdr’ should appear (as SKIP-CDR) in the doc string (emacs-lisp-checkdoc)
 dash.el  1641     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1669     warning         Argument ‘props’ should appear (as PROPS) in the doc string (emacs-lisp-checkdoc)
 dash.el  1714     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1814     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1828   1 error           `dash-expand:&hash' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1832   1 error           `dash-expand:&plist' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1836   1 error           `dash-expand:&alist' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1840   1 error           `dash-expand:&hash?' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 dash.el  1875     warning         Argument ‘match-form’ should appear (as MATCH-FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  1928   1 error           "-let*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  1947   1 error           "-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2121   1 error           "-lambda" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2154   1 error           "-setq" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2155     warning         Argument ‘forms’ should appear (as FORMS) in the doc string (emacs-lisp-checkdoc)
 dash.el  2208   1 error           "-if-let*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2209     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2227   1 error           "-if-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2228     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2228     warning         Argument ‘var-val’ should appear (as VAR-VAL) in the doc string (emacs-lisp-checkdoc)
 dash.el  2228     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2238   1 error           "--if-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2239     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2239     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2245   1 error           "-when-let*" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2246     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2246     warning         Argument ‘body’ should appear (as BODY) in the doc string (emacs-lisp-checkdoc)
 dash.el  2257   1 error           "-when-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2258     warning         Argument ‘var-val’ should appear (as VAR-VAL) in the doc string (emacs-lisp-checkdoc)
 dash.el  2258     warning         Probably "evaluates" should be imperative "evaluate" (emacs-lisp-checkdoc)
 dash.el  2267   1 error           "--when-let" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2268     warning         Argument ‘body’ should appear (as BODY) in the doc string (emacs-lisp-checkdoc)
 dash.el  2273   1 error           "-compare-fn" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2279   1 error           "-distinct" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2280     warning         Argument ‘list’ should appear (as LIST) in the doc string (emacs-lisp-checkdoc)
 dash.el  2302   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2304   1 error           "-union" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2305     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  2323   1 error           "-intersection" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2324     warning         Some lines are over 80 columns wide (emacs-lisp-checkdoc)
 dash.el  2329   1 error           "-difference" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2335   1 error           "-powerset" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2342   1 error           "-permutations" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2351   1 error           "-inits" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2359   1 error           "-tails" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2363   1 error           "-common-prefix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2369   1 error           "-common-suffix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2373   1 error           "-contains?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2393   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2395   1 error           "-same-items?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2407   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2409   1 error           "-is-prefix?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2418   1 error           "-is-suffix?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2425   1 error           "-is-infix?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2438   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2439   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2440   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2442   1 error           "-sort" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2449   1 error           "--sort" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2450     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2454   1 error           "-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2463   1 error           "-repeat" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2471   1 error           "-sum" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2476   1 error           "-running-sum" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2485   1 error           "-product" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2490   1 error           "-running-product" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2499   1 error           "-max" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2504   1 error           "-min" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2509   1 error           "-max-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2510     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2517   1 error           "-min-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2518     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 dash.el  2525   1 error           "--max-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2526     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2532   1 error           "--min-by" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2533     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2539   1 error           "-iterate" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2553   1 error           "-fix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2563   1 error           "--fix" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2564     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2567   1 error           "-unfold" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2583   1 error           "--unfold" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2584     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2588   1 error           "-cons-pair?" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2597   1 error           Aliases should start with the package's prefix "dash". (emacs-lisp-package)
 dash.el  2599   1 error           "-cons-to-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2600     warning         Argument ‘con’ should appear (as CON) in the doc string (emacs-lisp-checkdoc)
 dash.el  2604   1 error           "-value-to-list" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2605     warning         Argument ‘val’ should appear (as VAL) in the doc string (emacs-lisp-checkdoc)
 dash.el  2616   1 error           "-tree-mapreduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2633   1 error           "--tree-mapreduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2634     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2638   1 error           "-tree-mapreduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2655   1 error           "--tree-mapreduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2656     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2660   1 error           "-tree-map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2669   1 error           "--tree-map" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2670     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2674   1 error           "-tree-reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2690   1 error           "--tree-reduce-from" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2691     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2695   1 error           "-tree-reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2710   1 error           "--tree-reduce" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2711     warning         Argument ‘form’ should appear (as FORM) in the doc string (emacs-lisp-checkdoc)
 dash.el  2715   1 error           "-tree-map-nodes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2728   1 error           "--tree-map-nodes" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2729     warning         Argument ‘pred’ should appear (as PRED) in the doc string (emacs-lisp-checkdoc)
 dash.el  2732   1 error           "-tree-seq" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2747   1 error           "--tree-seq" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2748     warning         Argument ‘branch’ should appear (as BRANCH) in the doc string (emacs-lisp-checkdoc)
 dash.el  2751   1 error           "-clone" doesn't start with package's prefix "dash". (emacs-lisp-package)
 dash.el  2761   4 warning         `eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
 dash.el  3033  30 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 dash.el  3039  35 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
```