### PR TITLE
Use github actions instead of travis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: CI
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - '24.1'
+          - '24.2'
+          - '24.3'
+          - '24.4'
+          - '24.5'
+          - '25.1'
+          - '25.2'
+          - '25.3'
+          - '26.1'
+          - '26.2'
+          - '26.3'
+          - 'snapshot'
+        include:
+          - emacs_version: 'snapshot'
+            allow_failure: true
+    steps:
+    - uses: actions/checkout@v1
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - name: Run tests
+      if: matrix.allow_failure != true
+      run: './run-tests.sh'
+
+    - name: Run tests (allow failure)
+      if: matrix.allow_failure == true
+      run: './run-tests.sh || true'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img align="right" src="https://raw.github.com/magnars/dash.el/master/rainbow-dash.png"> dash.el [![Build Status](https://secure.travis-ci.org/magnars/dash.el.png)](http://travis-ci.org/magnars/dash.el)
+# <img align="right" src="https://raw.github.com/magnars/dash.el/master/rainbow-dash.png"> dash.el ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/magnars/dash.el/CI)
 
 A modern list api for Emacs. No 'cl required.
 

--- a/readme-template.md
+++ b/readme-template.md
@@ -1,4 +1,4 @@
-# <img align="right" src="https://raw.github.com/magnars/dash.el/master/rainbow-dash.png"> dash.el [![Build Status](https://secure.travis-ci.org/magnars/dash.el.png)](http://travis-ci.org/magnars/dash.el)
+# <img align="right" src="https://raw.github.com/magnars/dash.el/master/rainbow-dash.png"> dash.el ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/magnars/dash.el/CI)
 
 A modern list api for Emacs. No 'cl required.
 


### PR DESCRIPTION
Hi! Your travis CI with something wrong Emacs-26.
I suggest switch GitHub Actions using purcell's [setup-emacs](https://github.com/purcell/setup-emacs) from TravisCI.

I have checked the workflow works well in my fork ([log](https://github.com/conao3/dash.el/commit/d38088ffdcf48696670ec11d113451b50c5089d7/checks?check_suite_id=338889566))