### PR TITLE
Various Texinfo manual improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # ctags, etags.
 TAGS
+
+# Generated Info manual.
+dash.info

--- a/dash-template.texi
+++ b/dash-template.texi
@@ -1,40 +1,35 @@
 \input texinfo    @c -*- texinfo -*-
 @c %**start of header
 @setfilename dash.info
-@settitle dash
+@set DASHVER @c [[ version ]]
+@settitle Dash: A modern list library for GNU Emacs.
 @documentencoding UTF-8
 @documentlanguage en
-@syncodeindex fn cp
-@dircategory Emacs
-@direntry
-* Dash: (dash.info). A modern list library for GNU Emacs
-@end direntry
 @c %**end of header
 
 @copying
-This manual is for @code{dash.el} version 2.17.0.
+This manual is for Dash version @value{DASHVER}.
 
 Copyright @copyright{} 2012--2021 Free Software Foundation, Inc.
 
 @quotation
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see @uref{https://www.gnu.org/licenses/}.
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with the
+Invariant Sections being ``GNU General Public License,'' and no
+Front-Cover Texts or Back-Cover Texts.  A copy of the license is
+included in the section entitled ``GNU Free Documentation License''.
 @end quotation
 @end copying
 
-@finalout
+@dircategory Emacs
+@direntry
+* Dash: (dash.info).    A modern list library for GNU Emacs.
+@end direntry
+
 @titlepage
-@title Dash
+@title Dash Manual
+@subtitle For Dash Version @value{DASHVER}.
 @author Magnar Sveen
 @page
 @vskip 0pt plus 1filll
@@ -45,23 +40,29 @@ along with this program.  If not, see @uref{https://www.gnu.org/licenses/}.
 
 @ifnottex
 @node Top
-@top dash
+@top Dash
+
 @insertcopying
 @end ifnottex
 
 @menu
-* Installation::
-* Functions::
-* Development::
-* Index::
+* Installation::        Installing and configuring Dash.
+* Functions::           Dash API reference.
+* Development::         Contributing to Dash development.
+
+Appendices
+
+* FDL::                 The license for this documentation.
+* GPL::                 Conditions for copying and changing Dash.
+* Index::               Index including functions and macros.
 
 @detailmenu
---- The Detailed Node Listing ---
+ --- The Detailed Node Listing ---
 
 Installation
 
-* Using in a package::
-* Fontification of special variables::
+* Using in a package::  Listing Dash as a package dependency.
+* Fontification of special variables::  Font Lock of anaphoric macro variables.
 
 Functions
 
@@ -69,9 +70,9 @@ Functions
 
 Development
 
-* Contribute::          How to contribute
-* Changes::             List of significant changes by version
-* Contributors::        List of contributors
+* Contribute::          How to contribute.
+* Change log::          List of significant changes by version.
+* Contributors::        List of contributors.
 @end detailmenu
 @end menu
 
@@ -80,51 +81,57 @@ Development
 @node Installation
 @chapter Installation
 
-It's available on @uref{https://elpa.gnu.org/, GNU ELPA} and
-@uref{https://melpa.org/, MELPA}; use @code{M-x package-install}:
+Dash is available on @url{https://elpa.gnu.org/, GNU ELPA} and
+@url{https://melpa.org/, MELPA}, and can be installed with the
+standard command @code{package-install} (@pxref{Package
+Installation,,, emacs, The GNU Emacs Manual}).
 
 @table @kbd
-@item M-x package-install @key{RET} dash
-Install the dash library.
+@item M-x package-install @key{RET} dash @key{RET}
+Install the Dash library.
+
+@item M-x package-install @key{RET} dash-functional @key{RET}
+Install an optional library of additional function combinators.
 @end table
 
-@table @kbd
-@item M-x package-install @key{RET} dash-functional
-Optional, if you want the function combinators.
-@end table
-
-Alternatively, you can just dump @verb{~dash.el~} or
-@verb{~dash-functional.el~} in your load path somewhere.
+Alternatively, you can just dump @file{dash.el} or
+@file{dash-functional.el} in your load path somewhere.
 
 @menu
-* Using in a package::
-* Fontification of special variables::
+* Using in a package::  Listing Dash as a package dependency.
+* Fontification of special variables::  Font Lock of anaphoric macro variables.
 @end menu
 
 @node Using in a package
 @section Using in a package
 
-Add this to the big comment block at the top:
+If you use Dash in your own package, be sure to list it as a
+dependency in the library's headers as follows (@pxref{Library
+Headers,,, elisp, The Emacs Lisp Reference Manual}).
 
 @lisp
-;; Package-Requires: ((dash "2.17.0"))
+;; Package-Requires: ((dash "@value{DASHVER}"))
 @end lisp
 
-@noindent To get function combinators:
+The same goes for the @file{dash-functional.el} library of function
+combinators:
 
 @lisp
-;; Package-Requires: ((dash "2.17.0") (dash-functional "1.2.0"))
+;; Package-Requires: ((dash "@value{DASHVER}") (dash-functional "1.2.0"))
 @end lisp
 
 @node Fontification of special variables
 @section Fontification of special variables
 
-Font lock of special Dash variables (@code{it}, @code{acc}, etc.@:) in
-Emacs Lisp buffers can optionally be enabled with the autoloaded minor
-mode @code{dash-fontify-mode}.  In older Emacs versions which do not
-dynamically detect macros, the minor mode also fontifies Dash macro
-calls.
+@findex dash-fontify-mode
+The autoloaded minor mode @code{dash-fontify-mode} is provided for
+optional fontification of anaphoric Dash variables (@code{it},
+@code{acc}, etc.@:) in Emacs Lisp buffers using search-based Font Lock
+(@pxref{Font Lock,,, emacs, The GNU Emacs Manual}).  In older Emacs
+versions which do not dynamically detect macros, the minor mode also
+fontifies calls to Dash macros.
 
+@findex global-dash-fontify-mode
 To automatically enable the minor mode in all Emacs Lisp buffers, just
 call its autoloaded global counterpart
 @code{global-dash-fontify-mode}, either interactively or from your
@@ -137,33 +144,47 @@ call its autoloaded global counterpart
 @node Functions
 @chapter Functions
 
-This chapter contains reference documentation for the dash
-@abbr{application programming interface,API}.  All functions and
-constructs in the library are prefixed with a dash (-).
+This chapter contains reference documentation for the Dash
+@acronym{API, Application Programming Interface}.  The names of all
+public functions defined in the library are prefixed with a dash
+character (@samp{-}).
 
-There are also anaphoric versions of functions where that makes sense,
-prefixed with two dashes instead of one.
+The library also provides anaphoric macro versions of functions where
+that makes sense.  The names of these macros are prefixed with two
+dashes (@samp{--}) instead of one.
 
-For instance, while @code{-map} takes a function to map over the list,
-one can also use the anaphoric form with double dashes - which will
-then be executed with @code{it} exposed as the list item. Here's an
-example:
-
-@lisp
-(-map (lambda (n) (* n n)) '(1 2 3 4)) ;; normal version
-
-(--map (* it it) '(1 2 3 4)) ;; anaphoric version
-@end lisp
-
-@noindent Of course, the original can also be written like
+For instance, while the function @code{-map} applies a function to
+each element of a list, its anaphoric counterpart @code{--map}
+evaluates a form with the local variable @code{it} temporarily bound
+to the current list element instead.
 
 @lisp
-(defun square (n) (* n n))
+@group
+;; Normal version.
+(-map (lambda (n) (* n n)) '(1 2 3 4))
+    @result{} (1 4 9 16)
+@end group
 
-(-map 'square '(1 2 3 4))
+@group
+;; Anaphoric version.
+(--map (* it it) '(1 2 3 4))
+    @result{} (1 4 9 16)
+@end group
 @end lisp
 
-@noindent which demonstrates the usefulness of both versions.
+The normal version can, of course, also be written as in the following
+example, which demonstrates the utility of both versions.
+
+@lisp
+@group
+(defun my-square (n)
+  "Return N multiplied by itself."
+  (* n n))
+
+(-map #'my-square '(1 2 3 4))
+    @result{} (1 4 9 16)
+@end group
+@end lisp
 
 @menu
 @c [[ function-nodes ]]
@@ -174,284 +195,458 @@ example:
 @node Development
 @chapter Development
 
-The dash repository is hosted on GitHub:
-@uref{https://github.com/magnars/dash.el}
+The Dash repository is hosted on GitHub at
+@url{https://github.com/magnars/dash.el}.
 
 @menu
-* Contribute::          How to contribute
-* Changes::             List of significant changes by version
-* Contributors::        List of contributors
+* Contribute::          How to contribute.
+* Change log::          List of significant changes by version.
+* Contributors::        List of contributors.
 @end menu
 
 @node Contribute
 @section Contribute
 
-Yes, please do. Pure functions in the list manipulation realm only,
-please. There's a suite of tests in @verb{~dev/examples.el~}, so remember to add
-tests for your function, or it might get broken later.
+Yes, please do.  Pure functions in the list manipulation realm only,
+please.  There's a suite of examples/tests in @file{dev/examples.el},
+so remember to add tests for your additions, or they may get broken
+later.
 
-Run the tests with @code{./run-tests.sh}. Create the docs with
-@code{./create-docs.sh}. I highly recommend that you install these as a
-pre-commit hook, so that the tests are always running and the docs are
-always in sync:
+Run the tests with @samp{./run-tests.sh}.  Regenerate the docs with
+@samp{./create-docs.sh}.  Contributors are encouraged to install these
+commands as a Git pre-commit hook, so that the tests are always
+running and the docs are always in sync:
 
-@verbatim
-cp pre-commit.sh .git/hooks/pre-commit
-@end verbatim
+@example
+$ cp pre-commit.sh .git/hooks/pre-commit
+@end example
 
-Oh, and don't edit @file{README.md} directly, it is auto-generated.
-Change @file{readme-template.md} or @file{examples-to-docs.el}
-instead.  The same goes for the info manual.
+Oh, and don't edit @file{README.md} or @file{dash.texi} directly, as
+they are auto-generated.  Instead, change their respective templates
+@file{readme-template.md} or @file{dash-template.texi}.
 
-@node Changes
-@section Changes
+To ensure that Dash can be distributed with GNU ELPA or Emacs, we
+require that all contributors assign copyright to the Free Software
+Foundation.  For more on this, @pxref{Copyright Assignment,,, emacs,
+The GNU Emacs Manual}.
 
-@noindent Changes in 2.10:
+@node Change log
+@section Change log
 
-@itemize
-@item
-Add @code{-let} destructuring to @code{-if-let} and @code{-when-let}
-(Fredrik Bergroth)
-@end itemize
-
-@noindent Changes in 2.9:
-
-@itemize
-@item
-Add @code{-let}, @code{-let*} and @code{-lambda} with destructuring
-@item
-Add @code{-tree-seq} and @code{-tree-map-nodes}
-@item
-Add @code{-non-nil}
-@item
-Add @code{-fix}
-@item
-Add @code{-fixfn} (dash-functional 1.2)
-@item
-Add @code{-copy} (Wilfred Hughes)
-@end itemize
-
-@noindent Changes in 2.8:
+@table @asis
+@item Changes in 2.17:
 
 @itemize
 @item
-Add @code{-butlast}
+Sped up @code{-uniq} by using hash-tables when possible (Zhu Zihao).
+@item
+Fixed @code{-inits} to be non-destructive (Zach Shaftel).
+@item
+Fixed indent rules for @code{-some->} and family (Wouter Bolsterlee).
+@item
+Added @code{-zip-lists} which always returns a list of proper lists,
+even for two input lists (see issue #135).
 @end itemize
 
-@noindent Changes in 2.7:
+@item Changes in 2.16:
 
 @itemize
 @item
-@code{-zip} now supports more than two lists (Steve Lamb)
+Added @code{--doto}, anaphoric version of @code{-doto}.
 @item
-Add @code{-cycle}, @code{-pad}, @code{-annotate}, @code{-zip-fill}
-(Steve Lamb)
+Aliased @code{-cons-pair-p} to @code{-cons-pair?}.
 @item
-Add @code{-table}, @code{-table-flat} (finite cartesian product)
+Generalized @code{-rotate} for @math{|@var{n}|} greater than the
+length of the list (Brian Leung).
 @item
-Add @code{-flatten-n}
-@item
-@code{-slice} now supports "step" argument
-@item
-Add functional combinators @code{-iteratefn}, @code{-prodfn}
-@item
-Add @code{-replace}, @code{-splice}, @code{-splice-list} which
-generalize @code{-replace-at} and @code{-insert-at}
-@item
-Add @code{-compose}, @code{-iteratefn} and @code{-prodfn}
-(dash-functional 1.1)
+Added a mechanism to extend destructuring with custom matchers (Ivan
+Yonchovski).
 @end itemize
 
-@noindent Changes in 2.6:
+@item Changes in 2.15:
+
+This release brought new destructuring features, some new control flow
+functions, and performance optimizations.
 
 @itemize
 @item
-Add @code{-is-prefix-p}, @code{-is-suffix-p}, @code{-is-infix-p}
-(Matus Goljer)
+Added @code{-setq} with destructuring binding support similar to the
+@code{-let} family.
 @item
-Add @code{-iterate}, @code{-unfold} (Matus Goljer)
+Added smarter key destructuring in @code{-let} and friends where
+variables are auto-derived from keys.
 @item
-Add @code{-split-on}, @code{-split-when} (Matus Goljer)
+Allowed @code{-let} bindings without a source value form.
 @item
-Add @code{-find-last-index} (Matus Goljer)
+Added @code{-each-r} and @code{-each-r-while} (Paul Pogonyshev).
 @item
-Add @code{-list} (Johan Andersson)
+Added @code{-common-suffix} (Basil L. Contovounesios).
+@item
+Improved performance of folds (@code{-reduce} and friends) (Basil L.
+Contovounesios).
 @end itemize
 
-@noindent Changes in 2.5:
+@item Changes in 2.14:
+
+This release retired support for Emacs 23.
 
 @itemize
 @item
-Add @code{-same-items?} (Johan Andersson)
+Added Edebug support for threading macros (Wilfred Hughes).
 @item
-A few bugfixes
+Added @code{-unzip}.
+@item
+Added support for @code{-first-item} and @code{-last-item} as place
+forms (@pxref{Generalized Variables,,, elisp, The Emacs Lisp Reference
+Manual}).
+@item
+Added @code{-powerset} and @code{-permutations} (Mark Oteiza).
+@item
+Added @code{-as->} for threading a named variable (Zachary Kanfer).
+@item
+Added @code{-partition-after-pred}, @code{-partition-before-pred},
+@code{-partition-after-item}, and @code{-partition-before-item}
+(Zachary Kanfer).
+@item
+Fixed a bug in @code{-any-p} and friends testing for @code{null} on
+lists containing @code{nil}.
+@item
+Fixed infinite loop bug in @code{-zip} and @code{-interleave} when
+called with empty input.
+@item
+Added @code{-second-item} through @code{-fifth-item} as alternatives
+to @code{nth} (Wilfred Hughes).
+@item
+Added @code{-tails} and @code{-inits}.
+@item
+Added @code{-running-sum} and @code{-running-product}.
+@item
+Added the @code{-reductions[-r][-from]} family of functions (like
+@code{-reduce} but collecting intermediate results).
+@item
+Added @code{-common-prefix} (Basil L. Contovounesios).
 @end itemize
 
-@noindent Changes in 2.4:
+@item Changes in 2.13:
 
 @itemize
 @item
-Add @code{-snoc} (Matus Goljer)
+@code{-let} now supports @code{&alist} destructuring.
 @item
-Add @code{-replace-at}, @code{-update-at}, @code{-remove-at}, and
-@code{-remove-at-indices} (Matus Goljer)
+Various performance improvements.
+@item
+@code{-zip} might change in a future release to always return a list
+of proper lists.  Added @code{-zip-pair} for users who explicitly want
+the old behavior.
+@item
+Enabled lexical binding in @file{dash.el} for Emacs versions 24 or
+newer.
+@item
+Added @code{-select-column} and @code{-select-columns}.
+@item
+Fixed @code{-map-last} and @code{--remove-last} to be non-destructive.
+@item
+Added @code{-each-indexed} and @code{--each-indexed}.
+@item
+Added @code{-take-last} and @code{-drop-last}.
+@item
+Added the @code{-doto} macro.
+@item
+@code{-cut <>} is now treated as a function, consistent with
+@url{https://srfi.schemers.org/srfi-26/srfi-26.html, SRFI 26}.
 @end itemize
 
-@noindent Changes in 2.3:
+@item Changes in 2.12:
 
 @itemize
 @item
-Add tree operations (Matus Goljer)
+Added GNU ELPA support (Phillip Lord).
 @item
-Make font-lock optional
+Added @code{-some->}, @code{-some->>}, and @code{-some-->} macros (Cam
+Saul).
+@item
+@code{-is-suffix?} is now non-destructive.
+@item
+Faster hash table implementation for @code{-union}.
+@item
+Improvements to docstrings and examples.
 @end itemize
 
-@noindent Changes in 2.2:
+@item Changes in 2.11:
 
 @itemize
 @item
-Add @code{-compose} (Christina Whyte)
+Lots of clean up w.r.t. byte compilation, debug macros, and tests.
 @end itemize
 
-@noindent Changes in 2.1:
+@item Changes in 2.10:
 
 @itemize
 @item
-Add indexing operations (Matus Goljer)
+Added @code{-let} destructuring to @code{-if-let} and @code{-when-let}
+(Fredrik Bergroth).
 @end itemize
 
-@noindent Changes in 2.0:
+@item Changes in 2.9:
 
 @itemize
 @item
-Split out @code{dash-functional.el} (Matus Goljer)
+Added @code{-let}, @code{-let*}, and @code{-lambda} with
+destructuring.
 @item
-Add @code{-andfn}, @code{-orfn}, @code{-not}, @code{-cut},
-@code{-const}, @code{-flip} and @code{-on}. (Matus Goljer)
+Added @code{-tree-seq} and @code{-tree-map-nodes}.
 @item
-Fix @code{-min}, @code{-max}, @code{-min-by} and @code{-max-by} (Matus
-Goljer)
+Added @code{-non-nil}.
+@item
+Added @code{-fix}.
+@item
+Added @code{-fixfn} (@samp{dash-functional} version 1.2).
+@item
+Added @code{-copy} (Wilfred Hughes).
 @end itemize
 
-@noindent Changes in 1.8:
+@item Changes in 2.8:
 
 @itemize
 @item
-Add @code{-first-item} and @code{-last-item} (Wilfred Hughes)
+Added @code{-butlast}.
 @end itemize
 
-@noindent Changes in 1.7:
+@item Changes in 2.7:
 
 @itemize
 @item
-Add @code{-rotate} (Matus Goljer)
+@code{-zip} now supports more than two lists (Steve Lamb).
+@item
+Added @code{-cycle}, @code{-pad}, @code{-annotate}, and
+@code{-zip-fill} (Steve Lamb).
+@item
+Added @code{-table}, @code{-table-flat} (finite Cartesian product).
+@item
+Added @code{-flatten-n}.
+@item
+@code{-slice} now supports a ``step'' argument.
+@item
+Added functional combinators @code{-iteratefn} and @code{-prodfn}.
+@item
+Added @code{-replace}, @code{-splice}, and @code{-splice-list} which
+generalize @code{-replace-at} and @code{-insert-at}.
+@item
+Added @code{-compose}, @code{-iteratefn}, and @code{-prodfn}
+(@samp{dash-functional} version 1.1).
 @end itemize
 
-@noindent Changes in 1.6:
+@item Changes in 2.6:
 
 @itemize
 @item
-Add @code{-min}, @code{-max}, @code{-min-by} and @code{-max-by} (Johan
-Andersson)
+Added @code{-is-prefix-p}, @code{-is-suffix-p}, and @code{-is-infix-p}
+(Matus Goljer).
+@item
+Added @code{-iterate} and @code{-unfold} (Matus Goljer).
+@item
+Added @code{-split-on} and @code{-split-when} (Matus Goljer).
+@item
+Added @code{-find-last-index} (Matus Goljer).
+@item
+Added @code{-list} (Johan Andersson).
 @end itemize
 
-@noindent Changes in 1.5:
+@item Changes in 2.5:
 
 @itemize
 @item
-Add @code{-sum} and @code{-product} (Johan Andersson)
+Added @code{-same-items?} (Johan Andersson).
+@item
+Various bugfixes.
 @end itemize
 
-@noindent Changes in 1.4:
+@item Changes in 2.4:
 
 @itemize
 @item
-Add @code{-sort}
+Added @code{-snoc} (Matus Goljer).
 @item
-Add @code{-reduce-r} (Matus Goljer)
-@item
-Add @code{-reduce-r-from} (Matus Goljer)
+Added @code{-replace-at}, @code{-update-at}, @code{-remove-at}, and
+@code{-remove-at-indices} (Matus Goljer).
 @end itemize
 
-@noindent Changes in 1.3:
+@item Changes in 2.3:
 
 @itemize
 @item
-Add @code{-partition-in-steps}
+Added tree operations (Matus Goljer).
 @item
-Add @code{-partition-all-in-steps}
+Made Font Lock optional.
 @end itemize
 
-@noindent Changes in 1.2:
+@item Changes in 2.2:
 
 @itemize
 @item
-Add @code{-last} (Matus Goljer)
-@item
-Add @code{-insert-at} (Emanuel Evans)
-@item
-Add @code{-when-let} and @code{-if-let} (Emanuel Evans)
-@item
-Add @code{-when-let*} and @code{-if-let*} (Emanuel Evans)
-@item
-Some bugfixes
+Added @code{-compose} (Christina Whyte).
 @end itemize
+
+@item Changes in 2.1:
+
+@itemize
+@item
+Added indexing operations (Matus Goljer).
+@end itemize
+
+@item Changes in 2.0:
+
+@itemize
+@item
+Split out @file{dash-functional.el} (Matus Goljer).
+@item
+Added @code{-andfn}, @code{-orfn}, @code{-not}, @code{-cut},
+@code{-const}, @code{-flip}, and @code{-on} (Matus Goljer).
+@item
+Fixed @code{-min}, @code{-max}, @code{-min-by}, and @code{-max-by}
+(Matus Goljer).
+@end itemize
+
+@item Changes in 1.8:
+
+@itemize
+@item
+Added @code{-first-item} and @code{-last-item} (Wilfred Hughes).
+@end itemize
+
+@item Changes in 1.7:
+
+@itemize
+@item
+Added @code{-rotate} (Matus Goljer).
+@end itemize
+
+@item Changes in 1.6:
+
+@itemize
+@item
+Added @code{-min}, @code{-max}, @code{-min-by}, and @code{-max-by}
+(Johan Andersson).
+@end itemize
+
+@item Changes in 1.5:
+
+@itemize
+@item
+Added @code{-sum} and @code{-product} (Johan Andersson).
+@end itemize
+
+@item Changes in 1.4:
+
+@itemize
+@item
+Added @code{-sort}.
+@item
+Added @code{-reduce-r} (Matus Goljer).
+@item
+Added @code{-reduce-r-from} (Matus Goljer).
+@end itemize
+
+@item Changes in 1.3:
+
+@itemize
+@item
+Added @code{-partition-in-steps}.
+@item
+Added @code{-partition-all-in-steps}.
+@end itemize
+
+@item Changes in 1.2:
+
+@itemize
+@item
+Added @code{-last} (Matus Goljer).
+@item
+Added @code{-insert-at} (Emanuel Evans).
+@item
+Added @code{-when-let} and @code{-if-let} (Emanuel Evans).
+@item
+Added @code{-when-let*} and @code{-if-let*} (Emanuel Evans).
+@item
+Various bugfixes.
+@end itemize
+@end table
 
 @node Contributors
 @section Contributors
 
 @itemize
 @item
-@uref{https://github.com/Fuco1,Matus Goljer} contributed lots of
+@url{https://github.com/Fuco1, Matus Goljer} contributed lots of
 features and functions.
 @item
-@uref{https://github.com/tkf,Takafumi Arakaki} contributed
+@url{https://github.com/tkf, Takafumi Arakaki} contributed
 @code{-group-by}.
 @item
-@uref{https://github.com/tali713,tali713} is the author of
+@url{https://github.com/tali713, tali713} is the author of
 @code{-applify}.
 @item
-@uref{https://github.com/vemv,Víctor M. Valenzuela} contributed
+@url{https://github.com/vemv, V@'{i}ctor M. Valenzuela} contributed
 @code{-repeat}.
 @item
-@uref{https://github.com/nicferrier,Nic Ferrier} contributed
+@url{https://github.com/nicferrier, Nic Ferrier} contributed
 @code{-cons*}.
 @item
-@uref{https://github.com/Wilfred,Wilfred Hughes} contributed
-@code{-slice}, @code{-first-item} and @code{-last-item}.
+@url{https://github.com/Wilfred, Wilfred Hughes} contributed
+@code{-slice}, @code{-first-item}, and @code{-last-item}.
 @item
-@uref{https://github.com/shosti,Emanuel Evans} contributed
-@code{-if-let}, @code{-when-let} and @code{-insert-at}.
+@url{https://github.com/shosti, Emanuel Evans} contributed
+@code{-if-let}, @code{-when-let}, and @code{-insert-at}.
 @item
-@uref{https://github.com/rejeep,Johan Andersson} contributed
-@code{-sum}, @code{-product} and @code{-same-items?}
+@url{https://github.com/rejeep, Johan Andersson} contributed
+@code{-sum}, @code{-product}, and @code{-same-items?}.
 @item
-@uref{https://github.com/kurisuwhyte,Christina Whyte} contributed
-@code{-compose}
+@url{https://github.com/kurisuwhyte, Christina Whyte} contributed
+@code{-compose}.
 @item
-@uref{https://github.com/steventlamb,Steve Lamb} contributed
-@code{-cycle}, @code{-pad}, @code{-annotate}, @code{-zip-fill} and an
-n-ary version of @code{-zip}.
+@url{https://github.com/steventlamb, Steve Lamb} contributed
+@code{-cycle}, @code{-pad}, @code{-annotate}, @code{-zip-fill}, and a
+variadic version of @code{-zip}.
 @item
-@uref{https://github.com/fbergroth,Fredrik Bergroth} made the
-@code{-if-let} family use @code{-let} destructuring and improved
+@url{https://github.com/fbergroth, Fredrik Bergroth} made the
+@code{-if-let} family use @code{-let} destructuring and improved the
 script for generating documentation.
 @item
-@uref{https://github.com/holomorph,Mark Oteiza} contributed the
-script to create an info manual.
+@url{https://github.com/holomorph, Mark Oteiza} contributed the
+script to create an Info manual.
 @item
-@uref{https://github.com/wasamasa,Vasilij Schneidermann} contributed
+@url{https://github.com/wasamasa, Vasilij Schneidermann} contributed
 @code{-some}.
 @item
-@uref{https://github.com/occidens,William West} made @code{-fixfn}
+@url{https://github.com/occidens, William West} made @code{-fixfn}
 more robust at handling floats.
+@item
+@url{https://github.com/camsaul, Cam Saul} contributed @code{-some->},
+@code{-some->>}, and @code{-some-->}.
+@item
+@url{https://github.com/basil-conto, Basil L. Contovounesios} contributed
+@code{-common-prefix}.
+@item
+@url{https://github.com/doublep, Paul Pogonyshev} contributed
+@code{-each-r} and @code{-each-r-while}.
 @end itemize
 
 Thanks!
 
+New contributors are very welcome.  @xref{Contribute}.
+
+@c Appendices.
+
+@node FDL
+@appendix GNU Free Documentation License
+@include doc/fdl.texi
+
+@node GPL
+@appendix GNU General Public License
+@include doc/gpl.texi
+
 @node Index
 @unnumbered Index
-
-@printindex cp
+@printindex fn
 
 @bye

--- a/dash.texi
+++ b/dash.texi
@@ -1,40 +1,35 @@
 \input texinfo    @c -*- texinfo -*-
 @c %**start of header
 @setfilename dash.info
-@settitle dash
+@set DASHVER 2.17.0
+@settitle Dash: A modern list library for GNU Emacs.
 @documentencoding UTF-8
 @documentlanguage en
-@syncodeindex fn cp
-@dircategory Emacs
-@direntry
-* Dash: (dash.info). A modern list library for GNU Emacs
-@end direntry
 @c %**end of header
 
 @copying
-This manual is for @code{dash.el} version 2.17.0.
+This manual is for Dash version @value{DASHVER}.
 
 Copyright @copyright{} 2012--2021 Free Software Foundation, Inc.
 
 @quotation
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see @uref{https://www.gnu.org/licenses/}.
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with the
+Invariant Sections being ``GNU General Public License,'' and no
+Front-Cover Texts or Back-Cover Texts.  A copy of the license is
+included in the section entitled ``GNU Free Documentation License''.
 @end quotation
 @end copying
 
-@finalout
+@dircategory Emacs
+@direntry
+* Dash: (dash.info).    A modern list library for GNU Emacs.
+@end direntry
+
 @titlepage
-@title Dash
+@title Dash Manual
+@subtitle For Dash Version @value{DASHVER}.
 @author Magnar Sveen
 @page
 @vskip 0pt plus 1filll
@@ -45,23 +40,29 @@ along with this program.  If not, see @uref{https://www.gnu.org/licenses/}.
 
 @ifnottex
 @node Top
-@top dash
+@top Dash
+
 @insertcopying
 @end ifnottex
 
 @menu
-* Installation::
-* Functions::
-* Development::
-* Index::
+* Installation::        Installing and configuring Dash.
+* Functions::           Dash API reference.
+* Development::         Contributing to Dash development.
+
+Appendices
+
+* FDL::                 The license for this documentation.
+* GPL::                 Conditions for copying and changing Dash.
+* Index::               Index including functions and macros.
 
 @detailmenu
---- The Detailed Node Listing ---
+ --- The Detailed Node Listing ---
 
 Installation
 
-* Using in a package::
-* Fontification of special variables::
+* Using in a package::  Listing Dash as a package dependency.
+* Fontification of special variables::  Font Lock of anaphoric macro variables.
 
 Functions
 
@@ -84,9 +85,9 @@ Functions
 
 Development
 
-* Contribute::          How to contribute
-* Changes::             List of significant changes by version
-* Contributors::        List of contributors
+* Contribute::          How to contribute.
+* Change log::          List of significant changes by version.
+* Contributors::        List of contributors.
 @end detailmenu
 @end menu
 
@@ -95,51 +96,57 @@ Development
 @node Installation
 @chapter Installation
 
-It's available on @uref{https://elpa.gnu.org/, GNU ELPA} and
-@uref{https://melpa.org/, MELPA}; use @code{M-x package-install}:
+Dash is available on @url{https://elpa.gnu.org/, GNU ELPA} and
+@url{https://melpa.org/, MELPA}, and can be installed with the
+standard command @code{package-install} (@pxref{Package
+Installation,,, emacs, The GNU Emacs Manual}).
 
 @table @kbd
-@item M-x package-install @key{RET} dash
-Install the dash library.
+@item M-x package-install @key{RET} dash @key{RET}
+Install the Dash library.
+
+@item M-x package-install @key{RET} dash-functional @key{RET}
+Install an optional library of additional function combinators.
 @end table
 
-@table @kbd
-@item M-x package-install @key{RET} dash-functional
-Optional, if you want the function combinators.
-@end table
-
-Alternatively, you can just dump @verb{~dash.el~} or
-@verb{~dash-functional.el~} in your load path somewhere.
+Alternatively, you can just dump @file{dash.el} or
+@file{dash-functional.el} in your load path somewhere.
 
 @menu
-* Using in a package::
-* Fontification of special variables::
+* Using in a package::  Listing Dash as a package dependency.
+* Fontification of special variables::  Font Lock of anaphoric macro variables.
 @end menu
 
 @node Using in a package
 @section Using in a package
 
-Add this to the big comment block at the top:
+If you use Dash in your own package, be sure to list it as a
+dependency in the library's headers as follows (@pxref{Library
+Headers,,, elisp, The Emacs Lisp Reference Manual}).
 
 @lisp
-;; Package-Requires: ((dash "2.17.0"))
+;; Package-Requires: ((dash "@value{DASHVER}"))
 @end lisp
 
-@noindent To get function combinators:
+The same goes for the @file{dash-functional.el} library of function
+combinators:
 
 @lisp
-;; Package-Requires: ((dash "2.17.0") (dash-functional "1.2.0"))
+;; Package-Requires: ((dash "@value{DASHVER}") (dash-functional "1.2.0"))
 @end lisp
 
 @node Fontification of special variables
 @section Fontification of special variables
 
-Font lock of special Dash variables (@code{it}, @code{acc}, etc.@:) in
-Emacs Lisp buffers can optionally be enabled with the autoloaded minor
-mode @code{dash-fontify-mode}.  In older Emacs versions which do not
-dynamically detect macros, the minor mode also fontifies Dash macro
-calls.
+@findex dash-fontify-mode
+The autoloaded minor mode @code{dash-fontify-mode} is provided for
+optional fontification of anaphoric Dash variables (@code{it},
+@code{acc}, etc.@:) in Emacs Lisp buffers using search-based Font Lock
+(@pxref{Font Lock,,, emacs, The GNU Emacs Manual}).  In older Emacs
+versions which do not dynamically detect macros, the minor mode also
+fontifies calls to Dash macros.
 
+@findex global-dash-fontify-mode
 To automatically enable the minor mode in all Emacs Lisp buffers, just
 call its autoloaded global counterpart
 @code{global-dash-fontify-mode}, either interactively or from your
@@ -152,33 +159,47 @@ call its autoloaded global counterpart
 @node Functions
 @chapter Functions
 
-This chapter contains reference documentation for the dash
-@abbr{application programming interface,API}.  All functions and
-constructs in the library are prefixed with a dash (-).
+This chapter contains reference documentation for the Dash
+@acronym{API, Application Programming Interface}.  The names of all
+public functions defined in the library are prefixed with a dash
+character (@samp{-}).
 
-There are also anaphoric versions of functions where that makes sense,
-prefixed with two dashes instead of one.
+The library also provides anaphoric macro versions of functions where
+that makes sense.  The names of these macros are prefixed with two
+dashes (@samp{--}) instead of one.
 
-For instance, while @code{-map} takes a function to map over the list,
-one can also use the anaphoric form with double dashes - which will
-then be executed with @code{it} exposed as the list item. Here's an
-example:
-
-@lisp
-(-map (lambda (n) (* n n)) '(1 2 3 4)) ;; normal version
-
-(--map (* it it) '(1 2 3 4)) ;; anaphoric version
-@end lisp
-
-@noindent Of course, the original can also be written like
+For instance, while the function @code{-map} applies a function to
+each element of a list, its anaphoric counterpart @code{--map}
+evaluates a form with the local variable @code{it} temporarily bound
+to the current list element instead.
 
 @lisp
-(defun square (n) (* n n))
+@group
+;; Normal version.
+(-map (lambda (n) (* n n)) '(1 2 3 4))
+    @result{} (1 4 9 16)
+@end group
 
-(-map 'square '(1 2 3 4))
+@group
+;; Anaphoric version.
+(--map (* it it) '(1 2 3 4))
+    @result{} (1 4 9 16)
+@end group
 @end lisp
 
-@noindent which demonstrates the usefulness of both versions.
+The normal version can, of course, also be written as in the following
+example, which demonstrates the utility of both versions.
+
+@lisp
+@group
+(defun my-square (n)
+  "Return N multiplied by itself."
+  (* n n))
+
+(-map #'my-square '(1 2 3 4))
+    @result{} (1 4 9 16)
+@end group
+@end lisp
 
 @menu
 * Maps::
@@ -4436,284 +4457,458 @@ This function satisfies the following laws:
 @node Development
 @chapter Development
 
-The dash repository is hosted on GitHub:
-@uref{https://github.com/magnars/dash.el}
+The Dash repository is hosted on GitHub at
+@url{https://github.com/magnars/dash.el}.
 
 @menu
-* Contribute::          How to contribute
-* Changes::             List of significant changes by version
-* Contributors::        List of contributors
+* Contribute::          How to contribute.
+* Change log::          List of significant changes by version.
+* Contributors::        List of contributors.
 @end menu
 
 @node Contribute
 @section Contribute
 
-Yes, please do. Pure functions in the list manipulation realm only,
-please. There's a suite of tests in @verb{~dev/examples.el~}, so remember to add
-tests for your function, or it might get broken later.
+Yes, please do.  Pure functions in the list manipulation realm only,
+please.  There's a suite of examples/tests in @file{dev/examples.el},
+so remember to add tests for your additions, or they may get broken
+later.
 
-Run the tests with @code{./run-tests.sh}. Create the docs with
-@code{./create-docs.sh}. I highly recommend that you install these as a
-pre-commit hook, so that the tests are always running and the docs are
-always in sync:
+Run the tests with @samp{./run-tests.sh}.  Regenerate the docs with
+@samp{./create-docs.sh}.  Contributors are encouraged to install these
+commands as a Git pre-commit hook, so that the tests are always
+running and the docs are always in sync:
 
-@verbatim
-cp pre-commit.sh .git/hooks/pre-commit
-@end verbatim
+@example
+$ cp pre-commit.sh .git/hooks/pre-commit
+@end example
 
-Oh, and don't edit @file{README.md} directly, it is auto-generated.
-Change @file{readme-template.md} or @file{examples-to-docs.el}
-instead.  The same goes for the info manual.
+Oh, and don't edit @file{README.md} or @file{dash.texi} directly, as
+they are auto-generated.  Instead, change their respective templates
+@file{readme-template.md} or @file{dash-template.texi}.
 
-@node Changes
-@section Changes
+To ensure that Dash can be distributed with GNU ELPA or Emacs, we
+require that all contributors assign copyright to the Free Software
+Foundation.  For more on this, @pxref{Copyright Assignment,,, emacs,
+The GNU Emacs Manual}.
 
-@noindent Changes in 2.10:
+@node Change log
+@section Change log
 
-@itemize
-@item
-Add @code{-let} destructuring to @code{-if-let} and @code{-when-let}
-(Fredrik Bergroth)
-@end itemize
-
-@noindent Changes in 2.9:
-
-@itemize
-@item
-Add @code{-let}, @code{-let*} and @code{-lambda} with destructuring
-@item
-Add @code{-tree-seq} and @code{-tree-map-nodes}
-@item
-Add @code{-non-nil}
-@item
-Add @code{-fix}
-@item
-Add @code{-fixfn} (dash-functional 1.2)
-@item
-Add @code{-copy} (Wilfred Hughes)
-@end itemize
-
-@noindent Changes in 2.8:
+@table @asis
+@item Changes in 2.17:
 
 @itemize
 @item
-Add @code{-butlast}
+Sped up @code{-uniq} by using hash-tables when possible (Zhu Zihao).
+@item
+Fixed @code{-inits} to be non-destructive (Zach Shaftel).
+@item
+Fixed indent rules for @code{-some->} and family (Wouter Bolsterlee).
+@item
+Added @code{-zip-lists} which always returns a list of proper lists,
+even for two input lists (see issue #135).
 @end itemize
 
-@noindent Changes in 2.7:
+@item Changes in 2.16:
 
 @itemize
 @item
-@code{-zip} now supports more than two lists (Steve Lamb)
+Added @code{--doto}, anaphoric version of @code{-doto}.
 @item
-Add @code{-cycle}, @code{-pad}, @code{-annotate}, @code{-zip-fill}
-(Steve Lamb)
+Aliased @code{-cons-pair-p} to @code{-cons-pair?}.
 @item
-Add @code{-table}, @code{-table-flat} (finite cartesian product)
+Generalized @code{-rotate} for @math{|@var{n}|} greater than the
+length of the list (Brian Leung).
 @item
-Add @code{-flatten-n}
-@item
-@code{-slice} now supports "step" argument
-@item
-Add functional combinators @code{-iteratefn}, @code{-prodfn}
-@item
-Add @code{-replace}, @code{-splice}, @code{-splice-list} which
-generalize @code{-replace-at} and @code{-insert-at}
-@item
-Add @code{-compose}, @code{-iteratefn} and @code{-prodfn}
-(dash-functional 1.1)
+Added a mechanism to extend destructuring with custom matchers (Ivan
+Yonchovski).
 @end itemize
 
-@noindent Changes in 2.6:
+@item Changes in 2.15:
+
+This release brought new destructuring features, some new control flow
+functions, and performance optimizations.
 
 @itemize
 @item
-Add @code{-is-prefix-p}, @code{-is-suffix-p}, @code{-is-infix-p}
-(Matus Goljer)
+Added @code{-setq} with destructuring binding support similar to the
+@code{-let} family.
 @item
-Add @code{-iterate}, @code{-unfold} (Matus Goljer)
+Added smarter key destructuring in @code{-let} and friends where
+variables are auto-derived from keys.
 @item
-Add @code{-split-on}, @code{-split-when} (Matus Goljer)
+Allowed @code{-let} bindings without a source value form.
 @item
-Add @code{-find-last-index} (Matus Goljer)
+Added @code{-each-r} and @code{-each-r-while} (Paul Pogonyshev).
 @item
-Add @code{-list} (Johan Andersson)
+Added @code{-common-suffix} (Basil L. Contovounesios).
+@item
+Improved performance of folds (@code{-reduce} and friends) (Basil L.
+Contovounesios).
 @end itemize
 
-@noindent Changes in 2.5:
+@item Changes in 2.14:
+
+This release retired support for Emacs 23.
 
 @itemize
 @item
-Add @code{-same-items?} (Johan Andersson)
+Added Edebug support for threading macros (Wilfred Hughes).
 @item
-A few bugfixes
+Added @code{-unzip}.
+@item
+Added support for @code{-first-item} and @code{-last-item} as place
+forms (@pxref{Generalized Variables,,, elisp, The Emacs Lisp Reference
+Manual}).
+@item
+Added @code{-powerset} and @code{-permutations} (Mark Oteiza).
+@item
+Added @code{-as->} for threading a named variable (Zachary Kanfer).
+@item
+Added @code{-partition-after-pred}, @code{-partition-before-pred},
+@code{-partition-after-item}, and @code{-partition-before-item}
+(Zachary Kanfer).
+@item
+Fixed a bug in @code{-any-p} and friends testing for @code{null} on
+lists containing @code{nil}.
+@item
+Fixed infinite loop bug in @code{-zip} and @code{-interleave} when
+called with empty input.
+@item
+Added @code{-second-item} through @code{-fifth-item} as alternatives
+to @code{nth} (Wilfred Hughes).
+@item
+Added @code{-tails} and @code{-inits}.
+@item
+Added @code{-running-sum} and @code{-running-product}.
+@item
+Added the @code{-reductions[-r][-from]} family of functions (like
+@code{-reduce} but collecting intermediate results).
+@item
+Added @code{-common-prefix} (Basil L. Contovounesios).
 @end itemize
 
-@noindent Changes in 2.4:
+@item Changes in 2.13:
 
 @itemize
 @item
-Add @code{-snoc} (Matus Goljer)
+@code{-let} now supports @code{&alist} destructuring.
 @item
-Add @code{-replace-at}, @code{-update-at}, @code{-remove-at}, and
-@code{-remove-at-indices} (Matus Goljer)
+Various performance improvements.
+@item
+@code{-zip} might change in a future release to always return a list
+of proper lists.  Added @code{-zip-pair} for users who explicitly want
+the old behavior.
+@item
+Enabled lexical binding in @file{dash.el} for Emacs versions 24 or
+newer.
+@item
+Added @code{-select-column} and @code{-select-columns}.
+@item
+Fixed @code{-map-last} and @code{--remove-last} to be non-destructive.
+@item
+Added @code{-each-indexed} and @code{--each-indexed}.
+@item
+Added @code{-take-last} and @code{-drop-last}.
+@item
+Added the @code{-doto} macro.
+@item
+@code{-cut <>} is now treated as a function, consistent with
+@url{https://srfi.schemers.org/srfi-26/srfi-26.html, SRFI 26}.
 @end itemize
 
-@noindent Changes in 2.3:
+@item Changes in 2.12:
 
 @itemize
 @item
-Add tree operations (Matus Goljer)
+Added GNU ELPA support (Phillip Lord).
 @item
-Make font-lock optional
+Added @code{-some->}, @code{-some->>}, and @code{-some-->} macros (Cam
+Saul).
+@item
+@code{-is-suffix?} is now non-destructive.
+@item
+Faster hash table implementation for @code{-union}.
+@item
+Improvements to docstrings and examples.
 @end itemize
 
-@noindent Changes in 2.2:
+@item Changes in 2.11:
 
 @itemize
 @item
-Add @code{-compose} (Christina Whyte)
+Lots of clean up w.r.t. byte compilation, debug macros, and tests.
 @end itemize
 
-@noindent Changes in 2.1:
+@item Changes in 2.10:
 
 @itemize
 @item
-Add indexing operations (Matus Goljer)
+Added @code{-let} destructuring to @code{-if-let} and @code{-when-let}
+(Fredrik Bergroth).
 @end itemize
 
-@noindent Changes in 2.0:
+@item Changes in 2.9:
 
 @itemize
 @item
-Split out @code{dash-functional.el} (Matus Goljer)
+Added @code{-let}, @code{-let*}, and @code{-lambda} with
+destructuring.
 @item
-Add @code{-andfn}, @code{-orfn}, @code{-not}, @code{-cut},
-@code{-const}, @code{-flip} and @code{-on}. (Matus Goljer)
+Added @code{-tree-seq} and @code{-tree-map-nodes}.
 @item
-Fix @code{-min}, @code{-max}, @code{-min-by} and @code{-max-by} (Matus
-Goljer)
+Added @code{-non-nil}.
+@item
+Added @code{-fix}.
+@item
+Added @code{-fixfn} (@samp{dash-functional} version 1.2).
+@item
+Added @code{-copy} (Wilfred Hughes).
 @end itemize
 
-@noindent Changes in 1.8:
+@item Changes in 2.8:
 
 @itemize
 @item
-Add @code{-first-item} and @code{-last-item} (Wilfred Hughes)
+Added @code{-butlast}.
 @end itemize
 
-@noindent Changes in 1.7:
+@item Changes in 2.7:
 
 @itemize
 @item
-Add @code{-rotate} (Matus Goljer)
+@code{-zip} now supports more than two lists (Steve Lamb).
+@item
+Added @code{-cycle}, @code{-pad}, @code{-annotate}, and
+@code{-zip-fill} (Steve Lamb).
+@item
+Added @code{-table}, @code{-table-flat} (finite Cartesian product).
+@item
+Added @code{-flatten-n}.
+@item
+@code{-slice} now supports a ``step'' argument.
+@item
+Added functional combinators @code{-iteratefn} and @code{-prodfn}.
+@item
+Added @code{-replace}, @code{-splice}, and @code{-splice-list} which
+generalize @code{-replace-at} and @code{-insert-at}.
+@item
+Added @code{-compose}, @code{-iteratefn}, and @code{-prodfn}
+(@samp{dash-functional} version 1.1).
 @end itemize
 
-@noindent Changes in 1.6:
+@item Changes in 2.6:
 
 @itemize
 @item
-Add @code{-min}, @code{-max}, @code{-min-by} and @code{-max-by} (Johan
-Andersson)
+Added @code{-is-prefix-p}, @code{-is-suffix-p}, and @code{-is-infix-p}
+(Matus Goljer).
+@item
+Added @code{-iterate} and @code{-unfold} (Matus Goljer).
+@item
+Added @code{-split-on} and @code{-split-when} (Matus Goljer).
+@item
+Added @code{-find-last-index} (Matus Goljer).
+@item
+Added @code{-list} (Johan Andersson).
 @end itemize
 
-@noindent Changes in 1.5:
+@item Changes in 2.5:
 
 @itemize
 @item
-Add @code{-sum} and @code{-product} (Johan Andersson)
+Added @code{-same-items?} (Johan Andersson).
+@item
+Various bugfixes.
 @end itemize
 
-@noindent Changes in 1.4:
+@item Changes in 2.4:
 
 @itemize
 @item
-Add @code{-sort}
+Added @code{-snoc} (Matus Goljer).
 @item
-Add @code{-reduce-r} (Matus Goljer)
-@item
-Add @code{-reduce-r-from} (Matus Goljer)
+Added @code{-replace-at}, @code{-update-at}, @code{-remove-at}, and
+@code{-remove-at-indices} (Matus Goljer).
 @end itemize
 
-@noindent Changes in 1.3:
+@item Changes in 2.3:
 
 @itemize
 @item
-Add @code{-partition-in-steps}
+Added tree operations (Matus Goljer).
 @item
-Add @code{-partition-all-in-steps}
+Made Font Lock optional.
 @end itemize
 
-@noindent Changes in 1.2:
+@item Changes in 2.2:
 
 @itemize
 @item
-Add @code{-last} (Matus Goljer)
-@item
-Add @code{-insert-at} (Emanuel Evans)
-@item
-Add @code{-when-let} and @code{-if-let} (Emanuel Evans)
-@item
-Add @code{-when-let*} and @code{-if-let*} (Emanuel Evans)
-@item
-Some bugfixes
+Added @code{-compose} (Christina Whyte).
 @end itemize
+
+@item Changes in 2.1:
+
+@itemize
+@item
+Added indexing operations (Matus Goljer).
+@end itemize
+
+@item Changes in 2.0:
+
+@itemize
+@item
+Split out @file{dash-functional.el} (Matus Goljer).
+@item
+Added @code{-andfn}, @code{-orfn}, @code{-not}, @code{-cut},
+@code{-const}, @code{-flip}, and @code{-on} (Matus Goljer).
+@item
+Fixed @code{-min}, @code{-max}, @code{-min-by}, and @code{-max-by}
+(Matus Goljer).
+@end itemize
+
+@item Changes in 1.8:
+
+@itemize
+@item
+Added @code{-first-item} and @code{-last-item} (Wilfred Hughes).
+@end itemize
+
+@item Changes in 1.7:
+
+@itemize
+@item
+Added @code{-rotate} (Matus Goljer).
+@end itemize
+
+@item Changes in 1.6:
+
+@itemize
+@item
+Added @code{-min}, @code{-max}, @code{-min-by}, and @code{-max-by}
+(Johan Andersson).
+@end itemize
+
+@item Changes in 1.5:
+
+@itemize
+@item
+Added @code{-sum} and @code{-product} (Johan Andersson).
+@end itemize
+
+@item Changes in 1.4:
+
+@itemize
+@item
+Added @code{-sort}.
+@item
+Added @code{-reduce-r} (Matus Goljer).
+@item
+Added @code{-reduce-r-from} (Matus Goljer).
+@end itemize
+
+@item Changes in 1.3:
+
+@itemize
+@item
+Added @code{-partition-in-steps}.
+@item
+Added @code{-partition-all-in-steps}.
+@end itemize
+
+@item Changes in 1.2:
+
+@itemize
+@item
+Added @code{-last} (Matus Goljer).
+@item
+Added @code{-insert-at} (Emanuel Evans).
+@item
+Added @code{-when-let} and @code{-if-let} (Emanuel Evans).
+@item
+Added @code{-when-let*} and @code{-if-let*} (Emanuel Evans).
+@item
+Various bugfixes.
+@end itemize
+@end table
 
 @node Contributors
 @section Contributors
 
 @itemize
 @item
-@uref{https://github.com/Fuco1,Matus Goljer} contributed lots of
+@url{https://github.com/Fuco1, Matus Goljer} contributed lots of
 features and functions.
 @item
-@uref{https://github.com/tkf,Takafumi Arakaki} contributed
+@url{https://github.com/tkf, Takafumi Arakaki} contributed
 @code{-group-by}.
 @item
-@uref{https://github.com/tali713,tali713} is the author of
+@url{https://github.com/tali713, tali713} is the author of
 @code{-applify}.
 @item
-@uref{https://github.com/vemv,Víctor M. Valenzuela} contributed
+@url{https://github.com/vemv, V@'{i}ctor M. Valenzuela} contributed
 @code{-repeat}.
 @item
-@uref{https://github.com/nicferrier,Nic Ferrier} contributed
+@url{https://github.com/nicferrier, Nic Ferrier} contributed
 @code{-cons*}.
 @item
-@uref{https://github.com/Wilfred,Wilfred Hughes} contributed
-@code{-slice}, @code{-first-item} and @code{-last-item}.
+@url{https://github.com/Wilfred, Wilfred Hughes} contributed
+@code{-slice}, @code{-first-item}, and @code{-last-item}.
 @item
-@uref{https://github.com/shosti,Emanuel Evans} contributed
-@code{-if-let}, @code{-when-let} and @code{-insert-at}.
+@url{https://github.com/shosti, Emanuel Evans} contributed
+@code{-if-let}, @code{-when-let}, and @code{-insert-at}.
 @item
-@uref{https://github.com/rejeep,Johan Andersson} contributed
-@code{-sum}, @code{-product} and @code{-same-items?}
+@url{https://github.com/rejeep, Johan Andersson} contributed
+@code{-sum}, @code{-product}, and @code{-same-items?}.
 @item
-@uref{https://github.com/kurisuwhyte,Christina Whyte} contributed
-@code{-compose}
+@url{https://github.com/kurisuwhyte, Christina Whyte} contributed
+@code{-compose}.
 @item
-@uref{https://github.com/steventlamb,Steve Lamb} contributed
-@code{-cycle}, @code{-pad}, @code{-annotate}, @code{-zip-fill} and an
-n-ary version of @code{-zip}.
+@url{https://github.com/steventlamb, Steve Lamb} contributed
+@code{-cycle}, @code{-pad}, @code{-annotate}, @code{-zip-fill}, and a
+variadic version of @code{-zip}.
 @item
-@uref{https://github.com/fbergroth,Fredrik Bergroth} made the
-@code{-if-let} family use @code{-let} destructuring and improved
+@url{https://github.com/fbergroth, Fredrik Bergroth} made the
+@code{-if-let} family use @code{-let} destructuring and improved the
 script for generating documentation.
 @item
-@uref{https://github.com/holomorph,Mark Oteiza} contributed the
-script to create an info manual.
+@url{https://github.com/holomorph, Mark Oteiza} contributed the
+script to create an Info manual.
 @item
-@uref{https://github.com/wasamasa,Vasilij Schneidermann} contributed
+@url{https://github.com/wasamasa, Vasilij Schneidermann} contributed
 @code{-some}.
 @item
-@uref{https://github.com/occidens,William West} made @code{-fixfn}
+@url{https://github.com/occidens, William West} made @code{-fixfn}
 more robust at handling floats.
+@item
+@url{https://github.com/camsaul, Cam Saul} contributed @code{-some->},
+@code{-some->>}, and @code{-some-->}.
+@item
+@url{https://github.com/basil-conto, Basil L. Contovounesios} contributed
+@code{-common-prefix}.
+@item
+@url{https://github.com/doublep, Paul Pogonyshev} contributed
+@code{-each-r} and @code{-each-r-while}.
 @end itemize
 
 Thanks!
 
+New contributors are very welcome.  @xref{Contribute}.
+
+@c Appendices.
+
+@node FDL
+@appendix GNU Free Documentation License
+@include doc/fdl.texi
+
+@node GPL
+@appendix GNU General Public License
+@include doc/gpl.texi
+
 @node Index
 @unnumbered Index
-
-@printindex cp
+@printindex fn
 
 @bye

--- a/dev/examples-to-info.el
+++ b/dev/examples-to-info.el
@@ -24,6 +24,7 @@
 (require 'dash)
 (require 'dash-functional)
 (require 'help-fns)
+(require 'lisp-mnt)
 
 (setq text-quoting-style 'grave)
 
@@ -189,6 +190,9 @@ FUNCTION may reference an elisp function, alias, macro or a subr."
   (let ((functions (nreverse functions)))
     (with-temp-file "./dash.texi"
       (insert-file-contents-literally "./dash-template.texi")
+
+      (goto-and-remove "@c [[ version ]]")
+      (insert (lm-version "dash.el"))
 
       (goto-and-remove "@c [[ function-nodes ]]")
       (insert (mapconcat 'function-to-node

--- a/doc/fdl.texi
+++ b/doc/fdl.texi
@@ -1,0 +1,505 @@
+@c The GNU Free Documentation License.
+@center Version 1.3, 3 November 2008
+
+@c This file is intended to be included within another document,
+@c hence no sectioning command or @node.
+
+@display
+Copyright @copyright{} 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.
+@uref{https://fsf.org/}
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+@end display
+
+@enumerate 0
+@item
+PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document @dfn{free} in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of ``copyleft'', which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+@item
+APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License.  Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein.  The ``Document'', below,
+refers to any such manual or work.  Any member of the public is a
+licensee, and is addressed as ``you''.  You accept the license if you
+copy, modify or distribute the work in a way requiring permission
+under copyright law.
+
+A ``Modified Version'' of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A ``Secondary Section'' is a named appendix or a front-matter section
+of the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall
+subject (or to related matters) and contains nothing that could fall
+directly within that overall subject.  (Thus, if the Document is in
+part a textbook of mathematics, a Secondary Section may not explain
+any mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The ``Invariant Sections'' are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.  If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant.  The Document may contain zero
+Invariant Sections.  If the Document does not identify any Invariant
+Sections then there are none.
+
+The ``Cover Texts'' are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.  A Front-Cover Text may
+be at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A ``Transparent'' copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text.  A copy that is not ``Transparent'' is called ``Opaque''.
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, La@TeX{} input
+format, SGML or XML using a publicly available
+DTD, and standard-conforming simple HTML,
+PostScript or PDF designed for human modification.  Examples
+of transparent image formats include PNG, XCF and
+JPG@.  Opaque formats include proprietary formats that can be
+read and edited only by proprietary word processors, SGML or
+XML for which the DTD and/or processing tools are
+not generally available, and the machine-generated HTML,
+PostScript or PDF produced by some word processors for
+output purposes only.
+
+The ``Title Page'' means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, ``Title Page'' means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+The ``publisher'' means any person or entity that distributes copies
+of the Document to the public.
+
+A section ``Entitled XYZ'' means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language.  (Here XYZ stands for a
+specific section name mentioned below, such as ``Acknowledgements'',
+``Dedications'', ``Endorsements'', or ``History''.)  To ``Preserve the Title''
+of such a section when you modify the Document means that it remains a
+section ``Entitled XYZ'' according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document.  These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+@item
+VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+@item
+COPYING IN QUANTITY
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+
+@item
+MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+@enumerate A
+@item
+Use in the Title Page (and on the covers, if any) a title distinct
+from that of the Document, and from those of previous versions
+(which should, if there were any, be listed in the History section
+of the Document).  You may use the same title as a previous version
+if the original publisher of that version gives permission.
+
+@item
+List on the Title Page, as authors, one or more persons or entities
+responsible for authorship of the modifications in the Modified
+Version, together with at least five of the principal authors of the
+Document (all of its principal authors, if it has fewer than five),
+unless they release you from this requirement.
+
+@item
+State on the Title page the name of the publisher of the
+Modified Version, as the publisher.
+
+@item
+Preserve all the copyright notices of the Document.
+
+@item
+Add an appropriate copyright notice for your modifications
+adjacent to the other copyright notices.
+
+@item
+Include, immediately after the copyright notices, a license notice
+giving the public permission to use the Modified Version under the
+terms of this License, in the form shown in the Addendum below.
+
+@item
+Preserve in that license notice the full lists of Invariant Sections
+and required Cover Texts given in the Document's license notice.
+
+@item
+Include an unaltered copy of this License.
+
+@item
+Preserve the section Entitled ``History'', Preserve its Title, and add
+to it an item stating at least the title, year, new authors, and
+publisher of the Modified Version as given on the Title Page.  If
+there is no section Entitled ``History'' in the Document, create one
+stating the title, year, authors, and publisher of the Document as
+given on its Title Page, then add an item describing the Modified
+Version as stated in the previous sentence.
+
+@item
+Preserve the network location, if any, given in the Document for
+public access to a Transparent copy of the Document, and likewise
+the network locations given in the Document for previous versions
+it was based on.  These may be placed in the ``History'' section.
+You may omit a network location for a work that was published at
+least four years before the Document itself, or if the original
+publisher of the version it refers to gives permission.
+
+@item
+For any section Entitled ``Acknowledgements'' or ``Dedications'', Preserve
+the Title of the section, and preserve in the section all the
+substance and tone of each of the contributor acknowledgements and/or
+dedications given therein.
+
+@item
+Preserve all the Invariant Sections of the Document,
+unaltered in their text and in their titles.  Section numbers
+or the equivalent are not considered part of the section titles.
+
+@item
+Delete any section Entitled ``Endorsements''.  Such a section
+may not be included in the Modified Version.
+
+@item
+Do not retitle any existing section to be Entitled ``Endorsements'' or
+to conflict in title with any Invariant Section.
+
+@item
+Preserve any Warranty Disclaimers.
+@end enumerate
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled ``Endorsements'', provided it contains
+nothing but endorsements of your Modified Version by various
+parties---for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+@item
+COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled ``History''
+in the various original documents, forming one section Entitled
+``History''; likewise combine any sections Entitled ``Acknowledgements'',
+and any sections Entitled ``Dedications''.  You must delete all
+sections Entitled ``Endorsements.''
+
+@item
+COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+
+You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+
+@item
+AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an ``aggregate'' if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+@item
+TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers.  In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled ``Acknowledgements'',
+``Dedications'', or ``History'', the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+@item
+TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense, or distribute it is void, and
+will automatically terminate your rights under this License.
+
+However, if you cease all violation of this License, then your license
+from a particular copyright holder is reinstated (a) provisionally,
+unless and until the copyright holder explicitly and finally
+terminates your license, and (b) permanently, if the copyright holder
+fails to notify you of the violation by some reasonable means prior to
+60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, receipt of a copy of some or all of the same material does
+not give you any rights to use it.
+
+@item
+FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+@uref{https://www.gnu.org/licenses/}.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License ``or any later version'' applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.  If the Document
+specifies that a proxy can decide which future versions of this
+License can be used, that proxy's public statement of acceptance of a
+version permanently authorizes you to choose that version for the
+Document.
+
+@item
+RELICENSING
+
+``Massive Multiauthor Collaboration Site'' (or ``MMC Site'') means any
+World Wide Web server that publishes copyrightable works and also
+provides prominent facilities for anybody to edit those works.  A
+public wiki that anybody can edit is an example of such a server.  A
+``Massive Multiauthor Collaboration'' (or ``MMC'') contained in the
+site means any set of copyrightable works thus published on the MMC
+site.
+
+``CC-BY-SA'' means the Creative Commons Attribution-Share Alike 3.0
+license published by Creative Commons Corporation, a not-for-profit
+corporation with a principal place of business in San Francisco,
+California, as well as future copyleft versions of that license
+published by that same organization.
+
+``Incorporate'' means to publish or republish a Document, in whole or
+in part, as part of another Document.
+
+An MMC is ``eligible for relicensing'' if it is licensed under this
+License, and if all works that were first published under this License
+somewhere other than this MMC, and subsequently incorporated in whole
+or in part into the MMC, (1) had no cover texts or invariant sections,
+and (2) were thus incorporated prior to November 1, 2008.
+
+The operator of an MMC Site may republish an MMC contained in the site
+under CC-BY-SA on the same site at any time before August 1, 2009,
+provided the MMC is eligible for relicensing.
+
+@end enumerate
+
+@page
+@heading ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+@smallexample
+@group
+  Copyright (C)  @var{year}  @var{your name}.
+  Permission is granted to copy, distribute and/or modify this document
+  under the terms of the GNU Free Documentation License, Version 1.3
+  or any later version published by the Free Software Foundation;
+  with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
+  Texts.  A copy of the license is included in the section entitled ``GNU
+  Free Documentation License''.
+@end group
+@end smallexample
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
+replace the ``with@dots{}Texts.''@: line with this:
+
+@smallexample
+@group
+    with the Invariant Sections being @var{list their titles}, with
+    the Front-Cover Texts being @var{list}, and with the Back-Cover Texts
+    being @var{list}.
+@end group
+@end smallexample
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.
+
+@c Local Variables:
+@c ispell-local-pdict: "ispell-dict"
+@c End:

--- a/doc/gpl.texi
+++ b/doc/gpl.texi
@@ -1,0 +1,717 @@
+@c The GNU General Public License.
+@center Version 3, 29 June 2007
+
+@c This file is intended to be included within another document,
+@c hence no sectioning command or @node.
+
+@display
+Copyright @copyright{} 2007 Free Software Foundation, Inc. @url{https://fsf.org/}
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+@end display
+
+@heading Preamble
+
+The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom
+to share and change all versions of a program---to make sure it remains
+free software for all its users.  We, the Free Software Foundation,
+use the GNU General Public License for most of our software; it
+applies also to any other work released this way by its authors.  You
+can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you
+have certain responsibilities if you distribute copies of the
+software, or if you modify it: responsibilities to respect the freedom
+of others.
+
+For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too,
+receive or can get the source code.  And you must show them these
+terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the
+manufacturer can do so.  This is fundamentally incompatible with the
+aim of protecting users' freedom to change the software.  The
+systematic pattern of such abuse occurs in the area of products for
+individuals to use, which is precisely where it is most unacceptable.
+Therefore, we have designed this version of the GPL to prohibit the
+practice for those products.  If such problems arise substantially in
+other domains, we stand ready to extend this provision to those
+domains in future versions of the GPL, as needed to protect the
+freedom of users.
+
+Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish
+to avoid the special danger that patents applied to a free program
+could make it effectively proprietary.  To prevent this, the GPL
+assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+@heading TERMS AND CONDITIONS
+
+@enumerate 0
+@item Definitions.
+
+``This License'' refers to version 3 of the GNU General Public License.
+
+``Copyright'' also means copyright-like laws that apply to other kinds
+of works, such as semiconductor masks.
+
+``The Program'' refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as ``you''.  ``Licensees'' and
+``recipients'' may be individuals or organizations.
+
+To ``modify'' a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of
+an exact copy.  The resulting work is called a ``modified version'' of
+the earlier work or a work ``based on'' the earlier work.
+
+A ``covered work'' means either the unmodified Program or a work based
+on the Program.
+
+To ``propagate'' a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+To ``convey'' a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user
+through a computer network, with no transfer of a copy, is not
+conveying.
+
+An interactive user interface displays ``Appropriate Legal Notices'' to
+the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+@item Source Code.
+
+The ``source code'' for a work means the preferred form of the work for
+making modifications to it.  ``Object code'' means any non-source form
+of a work.
+
+A ``Standard Interface'' means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+The ``System Libraries'' of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+``Major Component'', in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+The ``Corresponding Source'' for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can
+regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same
+work.
+
+@item Basic Permissions.
+
+All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey,
+without conditions so long as your license otherwise remains in force.
+You may convey covered works to others for the sole purpose of having
+them make modifications exclusively for you, or provide you with
+facilities for running those works, provided that you comply with the
+terms of this License in conveying all material for which you do not
+control copyright.  Those thus making or running the covered works for
+you must do so exclusively on your behalf, under your direction and
+control, on terms that prohibit them from making any copies of your
+copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the
+conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+@item Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such
+circumvention is effected by exercising rights under this License with
+respect to the covered work, and you disclaim any intention to limit
+operation or modification of the work as a means of enforcing, against
+the work's users, your or third parties' legal rights to forbid
+circumvention of technological measures.
+
+@item Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+@item Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these
+conditions:
+
+@enumerate a
+@item
+The work must carry prominent notices stating that you modified it,
+and giving a relevant date.
+
+@item
+The work must carry prominent notices stating that it is released
+under this License and any conditions added under section 7.  This
+requirement modifies the requirement in section 4 to ``keep intact all
+notices''.
+
+@item
+You must license the entire work, as a whole, under this License to
+anyone who comes into possession of a copy.  This License will
+therefore apply, along with any applicable section 7 additional terms,
+to the whole of the work, and all its parts, regardless of how they
+are packaged.  This License gives no permission to license the work in
+any other way, but it does not invalidate such permission if you have
+separately received it.
+
+@item
+If the work has interactive user interfaces, each must display
+Appropriate Legal Notices; however, if the Program has interactive
+interfaces that do not display Appropriate Legal Notices, your work
+need not make them do so.
+@end enumerate
+
+A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+``aggregate'' if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+@item  Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms of
+sections 4 and 5, provided that you also convey the machine-readable
+Corresponding Source under the terms of this License, in one of these
+ways:
+
+@enumerate a
+@item
+Convey the object code in, or embodied in, a physical product
+(including a physical distribution medium), accompanied by the
+Corresponding Source fixed on a durable physical medium customarily
+used for software interchange.
+
+@item
+Convey the object code in, or embodied in, a physical product
+(including a physical distribution medium), accompanied by a written
+offer, valid for at least three years and valid for as long as you
+offer spare parts or customer support for that product model, to give
+anyone who possesses the object code either (1) a copy of the
+Corresponding Source for all the software in the product that is
+covered by this License, on a durable physical medium customarily used
+for software interchange, for a price no more than your reasonable
+cost of physically performing this conveying of source, or (2) access
+to copy the Corresponding Source from a network server at no charge.
+
+@item
+Convey individual copies of the object code with a copy of the written
+offer to provide the Corresponding Source.  This alternative is
+allowed only occasionally and noncommercially, and only if you
+received the object code with such an offer, in accord with subsection
+6b.
+
+@item
+Convey the object code by offering access from a designated place
+(gratis or for a charge), and offer equivalent access to the
+Corresponding Source in the same way through the same place at no
+further charge.  You need not require recipients to copy the
+Corresponding Source along with the object code.  If the place to copy
+the object code is a network server, the Corresponding Source may be
+on a different server (operated by you or a third party) that supports
+equivalent copying facilities, provided you maintain clear directions
+next to the object code saying where to find the Corresponding Source.
+Regardless of what server hosts the Corresponding Source, you remain
+obligated to ensure that it is available for as long as needed to
+satisfy these requirements.
+
+@item
+Convey the object code using peer-to-peer transmission, provided you
+inform other peers where the object code and Corresponding Source of
+the work are being offered to the general public at no charge under
+subsection 6d.
+
+@end enumerate
+
+A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+A ``User Product'' is either (1) a ``consumer product'', which means any
+tangible personal property which is normally used for personal,
+family, or household purposes, or (2) anything designed or sold for
+incorporation into a dwelling.  In determining whether a product is a
+consumer product, doubtful cases shall be resolved in favor of
+coverage.  For a particular product received by a particular user,
+``normally used'' refers to a typical or common use of that class of
+product, regardless of the status of the particular user or of the way
+in which the particular user actually uses, or expects or is expected
+to use, the product.  A product is a consumer product regardless of
+whether the product has substantial commercial, industrial or
+non-consumer uses, unless such uses represent the only significant
+mode of use of the product.
+
+``Installation Information'' for a User Product means any methods,
+procedures, authorization keys, or other information required to
+install and execute modified versions of a covered work in that User
+Product from a modified version of its Corresponding Source.  The
+information must suffice to ensure that the continued functioning of
+the modified object code is in no case prevented or interfered with
+solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or
+updates for a work that has been modified or installed by the
+recipient, or for the User Product in which it has been modified or
+installed.  Access to a network may be denied when the modification
+itself materially and adversely affects the operation of the network
+or violates the rules and protocols for communication across the
+network.
+
+Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+@item Additional Terms.
+
+``Additional permissions'' are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders
+of that material) supplement the terms of this License with terms:
+
+@enumerate a
+@item
+Disclaiming warranty or limiting liability differently from the terms
+of sections 15 and 16 of this License; or
+
+@item
+Requiring preservation of specified reasonable legal notices or author
+attributions in that material or in the Appropriate Legal Notices
+displayed by works containing it; or
+
+@item
+Prohibiting misrepresentation of the origin of that material, or
+requiring that modified versions of such material be marked in
+reasonable ways as different from the original version; or
+
+@item
+Limiting the use for publicity purposes of names of licensors or
+authors of the material; or
+
+@item
+Declining to grant rights under trademark law for use of some trade
+names, trademarks, or service marks; or
+
+@item
+Requiring indemnification of licensors and authors of that material by
+anyone who conveys the material (or modified versions of it) with
+contractual assumptions of liability to the recipient, for any
+liability that these contractual assumptions directly impose on those
+licensors and authors.
+@end enumerate
+
+All other non-permissive additional terms are considered ``further
+restrictions'' within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions; the
+above requirements apply either way.
+
+@item Termination.
+
+You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+However, if you cease all violation of this License, then your license
+from a particular copyright holder is reinstated (a) provisionally,
+unless and until the copyright holder explicitly and finally
+terminates your license, and (b) permanently, if the copyright holder
+fails to notify you of the violation by some reasonable means prior to
+60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+@item Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run
+a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+@item Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+An ``entity transaction'' is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+@item Patents.
+
+A ``contributor'' is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's ``contributor version''.
+
+A contributor's ``essential patent claims'' are all patent claims owned
+or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, ``control'' includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+In the following three paragraphs, a ``patent license'' is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To ``grant'' such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  ``Knowingly relying'' means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+A patent license is ``discriminatory'' if it does not include within the
+scope of its coverage, prohibits the exercise of, or is conditioned on
+the non-exercise of one or more of the rights that are specifically
+granted under this License.  You may not convey a covered work if you
+are a party to an arrangement with a third party that is in the
+business of distributing software, under which you make payment to the
+third party based on the extent of your activity of conveying the
+work, and under which the third party grants, to any of the parties
+who would receive the covered work from you, a discriminatory patent
+license (a) in connection with copies of the covered work conveyed by
+you (or copies made from those copies), or (b) primarily for and in
+connection with specific products or compilations that contain the
+covered work, unless you entered into that arrangement, or that patent
+license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+@item No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey
+a covered work so as to satisfy simultaneously your obligations under
+this License and any other pertinent obligations, then as a
+consequence you may not convey it at all.  For example, if you agree
+to terms that obligate you to collect a royalty for further conveying
+from those to whom you convey the Program, the only way you could
+satisfy both those terms and this License would be to refrain entirely
+from conveying the Program.
+
+@item Use with the GNU Affero General Public License.
+
+Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+@item Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions
+of the GNU General Public License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies that a certain numbered version of the GNU General Public
+License ``or any later version'' applies to it, you have the option of
+following the terms and conditions either of that numbered version or
+of any later version published by the Free Software Foundation.  If
+the Program does not specify a version number of the GNU General
+Public License, you may choose any version ever published by the Free
+Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions
+of the GNU General Public License can be used, that proxy's public
+statement of acceptance of a version permanently authorizes you to
+choose that version for the Program.
+
+Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+@item Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW@.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM ``AS IS'' WITHOUT
+WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE@.  THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE PROGRAM IS WITH YOU@.  SHOULD THE PROGRAM PROVE
+DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR
+CORRECTION.
+
+@item Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT
+NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR
+LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM
+TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER
+PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+@item Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+@end enumerate
+
+@heading END OF TERMS AND CONDITIONS
+
+@heading How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these
+terms.
+
+To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the ``copyright'' line and a pointer to where the full notice is found.
+
+@smallexample
+@var{one line to give the program's name and a brief idea of what it does.}
+Copyright (C) @var{year} @var{name of author}
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE@.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see @url{https://www.gnu.org/licenses/}.
+@end smallexample
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+@smallexample
+@var{program} Copyright (C) @var{year} @var{name of author}
+This program comes with ABSOLUTELY NO WARRANTY; for details type @samp{show w}.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type @samp{show c} for details.
+@end smallexample
+
+The hypothetical commands @samp{show w} and @samp{show c} should show
+the appropriate parts of the General Public License.  Of course, your
+program's commands might be different; for a GUI interface, you would
+use an ``about box''.
+
+You should also get your employer (if you work as a programmer) or school,
+if any, to sign a ``copyright disclaimer'' for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+@url{https://www.gnu.org/licenses/}.
+
+The GNU General Public License does not permit incorporating your
+program into proprietary programs.  If your program is a subroutine
+library, you may consider it more useful to permit linking proprietary
+applications with the library.  If this is what you want to do, use
+the GNU Lesser General Public License instead of this License.  But
+first, please read @url{https://www.gnu.org/licenses/why-not-lgpl.html}.


### PR DESCRIPTION
The main change here that I wanted to run by others first is changing the license of the Texinfo manual from [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html) to [FDL](https://www.gnu.org/licenses/fdl-1.3.en.html).

The rest of the changes are summarised below.

Cc: @holomorph 

---

* `.gitignore`: Ignore locally compiled Info manual.

* `doc/fdl.texi`:
* `doc/gpl.texi`: New files containing GNU FDL and GPL in Texinfo format.

* `dash-template.texi`: Include their contents as appendices, and license manual under the GNU FDL.  Define placeholder flag `DASHVER` for the current version of the `dash.el` package.  Fix titles, subtitle, directory file entry, markup, and menus.  Improve wording and cross-references.  Reconcile manual contents with those of `readme-template.md`, particularly the change log and list of contributors.  Generate a function rather than concept index, which is not used.

* `dev/examples-to-info.el`: Set `DASHVER` in `dash.texi` to the current version of the `dash.el` package.

* `dash.texi`: Regenerate manual.