### PR TITLE
Add info-lookup-symbol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ either interactively or from your `user-init-file`:
 (global-dash-fontify-mode)
 ```
 
+## Info symbol lookup
+
+While editing Elisp files, you can use `C-h S` (`info-lookup-symbol`)
+to look up Elisp symbols in the relevant Info manuals (see [`(emacs)
+Info
+Lookup`](https://gnu.org/software/emacs/manual/html_node/emacs/Info-Lookup.html)).
+To enable the same for Dash symbols, use the command
+`dash-register-info-lookup`.  It can be called directly when needed,
+or automatically from your `user-init-file`.  For example:
+
+```el
+(with-eval-after-load 'info-look
+  (dash-register-info-lookup))
+```
+
 ## Functions
 
 All functions and constructs in the library use a dash (`-`) prefix.

--- a/dash-template.texi
+++ b/dash-template.texi
@@ -64,6 +64,7 @@ Installation
 
 * Using in a package::  Listing Dash as a package dependency.
 * Fontification of special variables::  Font Lock of anaphoric macro variables.
+* Info symbol lookup::  Looking up Dash symbols in this manual.
 
 Functions
 
@@ -101,6 +102,7 @@ Alternatively, you can just dump @file{dash.el} or
 @menu
 * Using in a package::  Listing Dash as a package dependency.
 * Fontification of special variables::  Font Lock of anaphoric macro variables.
+* Info symbol lookup::  Looking up Dash symbols in this manual.
 @end menu
 
 @node Using in a package
@@ -140,6 +142,23 @@ call its autoloaded global counterpart
 
 @lisp
 (global-dash-fontify-mode)
+@end lisp
+
+@node Info symbol lookup
+@section Info symbol lookup
+
+@findex dash-register-info-lookup
+While editing Elisp files, you can use @kbd{C-h S}
+(@code{info-lookup-symbol}) to look up Elisp symbols in the relevant
+Info manuals (@pxref{Info Lookup,,, emacs, The GNU Emacs Manual}).  To
+enable the same for Dash symbols, use the command
+@code{dash-register-info-lookup}.  It can be called directly when
+needed, or automatically from your @code{user-init-file}.  For
+example:
+
+@lisp
+(with-eval-after-load 'info-look
+  (dash-register-info-lookup))
 @end lisp
 
 @node Functions

--- a/dash.texi
+++ b/dash.texi
@@ -64,6 +64,7 @@ Installation
 
 * Using in a package::  Listing Dash as a package dependency.
 * Fontification of special variables::  Font Lock of anaphoric macro variables.
+* Info symbol lookup::  Looking up Dash symbols in this manual.
 
 Functions
 
@@ -116,6 +117,7 @@ Alternatively, you can just dump @file{dash.el} or
 @menu
 * Using in a package::  Listing Dash as a package dependency.
 * Fontification of special variables::  Font Lock of anaphoric macro variables.
+* Info symbol lookup::  Looking up Dash symbols in this manual.
 @end menu
 
 @node Using in a package
@@ -155,6 +157,23 @@ call its autoloaded global counterpart
 
 @lisp
 (global-dash-fontify-mode)
+@end lisp
+
+@node Info symbol lookup
+@section Info symbol lookup
+
+@findex dash-register-info-lookup
+While editing Elisp files, you can use @kbd{C-h S}
+(@code{info-lookup-symbol}) to look up Elisp symbols in the relevant
+Info manuals (@pxref{Info Lookup,,, emacs, The GNU Emacs Manual}).  To
+enable the same for Dash symbols, use the command
+@code{dash-register-info-lookup}.  It can be called directly when
+needed, or automatically from your @code{user-init-file}.  For
+example:
+
+@lisp
+(with-eval-after-load 'info-look
+  (dash-register-info-lookup))
 @end lisp
 
 @node Functions

--- a/readme-template.md
+++ b/readme-template.md
@@ -58,6 +58,21 @@ either interactively or from your `user-init-file`:
 (global-dash-fontify-mode)
 ```
 
+## Info symbol lookup
+
+While editing Elisp files, you can use `C-h S` (`info-lookup-symbol`)
+to look up Elisp symbols in the relevant Info manuals (see [`(emacs)
+Info
+Lookup`](https://gnu.org/software/emacs/manual/html_node/emacs/Info-Lookup.html)).
+To enable the same for Dash symbols, use the command
+`dash-register-info-lookup`.  It can be called directly when needed,
+or automatically from your `user-init-file`.  For example:
+
+```el
+(with-eval-after-load 'info-look
+  (dash-register-info-lookup))
+```
+
 ## Functions
 
 All functions and constructs in the library use a dash (`-`) prefix.


### PR DESCRIPTION
Provide a command to register the Dash Info index under `emacs-lisp-mode` in `info-lookup-alist` for the benefit of `C-h S`, and provide an unloader function for `unload-feature` to undo this.

* `dash.el` (`dash--info-doc-spec`, `dash--info-elisp-docs`)
(`dash-register-info-lookup`, `dash-unload-function`): New definitions.
* `dash-template.texi` (`Info symbol lookup`):
* `readme-template.md` (`Info symbol lookup`): New sections.

* `README.md`:
* `dash.texi`: Regenerate docs.

Fixes #326.
Cc: @emacs18