### PR TITLE
Avoid evaluating file-local variables

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -2941,6 +2941,13 @@ structure such as plist or alist."
     ;; globally; detect and limit to their local anaphoric scope.
     (,(concat "\\_<" (regexp-opt '("acc" "it" "it-index" "other")) "\\_>")
      0 font-lock-variable-name-face)
+    ;; Macros in dev/examples.el.  Based on `lisp-mode-symbol-regexp'.
+    (,(concat "(" (regexp-opt '("defexamples" "def-example-group") t)
+              "\\_>[\t ]+\\(\\(?:\\sw\\|\\s_\\|\\\\.\\)*\\)")
+     (1 font-lock-keyword-face)
+     (2 font-lock-function-name-face))
+    ;; Symbols in dev/examples.el.
+    ,(concat "\\_<" (regexp-opt '("=>" "~>" "!!>")) "\\_>")
     ;; Elisp macro fontification was static prior to Emacs 25.
     ,@(when (< emacs-major-version 25)
         (let ((macs '("!cdr"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -1673,8 +1673,4 @@ value rather than consuming a list to produce a single value."
              (equal (funcall (-compose (-prodfn f g) (-prodfn ff gg)) input3)
                     (funcall (-prodfn (-compose f ff) (-compose g gg)) input3)))) => t)))
 
-;; Local Variables:
-;; eval: (font-lock-add-keywords nil '(("defexamples\\|def-example-group\\| => \\| !!> \\| ~>" (0 'font-lock-keyword-face)) ("(defexamples[[:blank:]]+\\(.*\\)" (1 'font-lock-function-name-face))))
-;; End:
-
 ;;; examples.el ends here


### PR DESCRIPTION
Are there any objections to moving the file-local `eval`ed Font Lock keywords in `dev/examples.el` to `dash-fontify-mode`?  I think this is a bit cleaner and also avoids the "are you sure you trust these file-local variables" prompt every time you visit `dev/examples.el`.

* `dev/examples.el`: Move `font-lock-keywords` from `Local Variables`...
* `dash.el` (`dash--keywords`): ...to here, for `dash-fontify-mode`.