### PR TITLE
Fix handling nils of -some-->

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Functions pretending lists are trees.
 * [-as->](#-as--value-variable-rest-forms) `(value variable &rest forms)`
 * [-some->](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [-some->>](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
-* [-some-->](#-some---x-optional-form-rest-more) `(x &optional form &rest more)`
+* [-some-->](#-some---x-rest-forms) `(x &rest forms)`
 * [-doto](#-doto-init-rest-forms) `(init &rest forms)`
 
 ### Binding
@@ -2321,7 +2321,7 @@ and when that result is non-nil, through the next form, etc.
 (-some->> '(2 4 6) (-last 'even?) (+ 100)) ;; => 106
 ```
 
-#### -some--> `(x &optional form &rest more)`
+#### -some--> `(x &rest forms)`
 
 When expr is non-nil, thread it through the first form (via [`-->`](#---x-rest-forms)),
 and when that result is non-nil, through the next form, etc.

--- a/dash.el
+++ b/dash.el
@@ -1751,16 +1751,16 @@ and when that result is non-nil, through the next form, etc."
                    (->> ,result ,form))
                  ,@more))))
 
-(defmacro -some--> (x &optional form &rest more)
+(defmacro -some--> (x &rest forms)
   "When expr is non-nil, thread it through the first form (via `-->'),
 and when that result is non-nil, through the next form, etc."
   (declare (debug ->)
            (indent 1))
-  (if (null form) x
+  (if (null forms) x
     (let ((result (make-symbol "result")))
       `(-some--> (-when-let (,result ,x)
-                   (--> ,result ,form))
-                 ,@more))))
+                   (--> ,result ,(car forms)))
+         ,@(cdr forms)))))
 
 (defmacro -doto (init &rest forms)
   "Evaluate INIT and pass it as argument to FORMS with `->'.

--- a/dash.texi
+++ b/dash.texi
@@ -3601,7 +3601,7 @@ and when that result is non-nil, through the next form, etc.
 @end defmac
 
 @anchor{-some-->}
-@defmac -some--> (x &optional form &rest more)
+@defmac -some--> (x &rest forms)
 When expr is non-nil, thread it through the first form (via @code{-->} (@pxref{-->})),
 and when that result is non-nil, through the next form, etc.
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -1284,7 +1284,8 @@ value rather than consuming a list to produce a single value."
     (-some--> "def" (concat "abc" it "ghi")) => "abcdefghi"
     (-some--> nil (concat "abc" it "ghi")) => nil
     (-some--> '(1 3 5) (-filter 'even? it) (append it it) (-map 'square it)) => nil
-    (-some--> '(2 4 6) (-filter 'even? it) (append it it) (-map 'square it)) => '(4 16 36 4 16 36))
+    (-some--> '(2 4 6) (-filter 'even? it) (append it it) (-map 'square it)) => '(4 16 36 4 16 36)
+    (-some--> 1 nil) !!> (void-function nil))
 
   (defexamples -doto
     (-doto (list 1 2 3) pop pop) => '(3)


### PR DESCRIPTION
Fix `-some-->` to handle nils in arguments as functions.
This is related to #341.

By this change, `-some-->` causes an error `Symbol’s function definition is void: nil` if nil appears at second or after in its arguments.

```emacs-lisp
ELISP> (-some--> 1 nil)
*** Eval error ***  Symbol’s function definition is void: nil
```
