### PR TITLE
Symbols with destructuring expansions are not vars

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -2214,7 +2214,9 @@ matchers based on the type of the expression.
 Key-value stores are disambiguated by placing a token &plist,
 &alist or &hash as a first item in the MATCH-FORM."
   (cond
-   ((symbolp match-form)
+   ((and (symbolp match-form)
+         ;; Don't bind things like &keys as if they were vars (#395).
+         (not (functionp (dash--get-expand-function match-form))))
     (dash--match-symbol match-form source))
    ((consp match-form)
     (cond


### PR DESCRIPTION
* `dash.el` (`dash--get-expand-function`): Return non-`nil` only if expansion symbol names an actual function.
(`dash--match-cons-1`): Simplify accordingly.
(`dash--match`): Don't bind symbols with expansion functions as if they were variables.

Fixes #395.