### PR TITLE
Fix clients of -compare-fn

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,27 @@ See the end of the file for license conditions.
 
 ## Change log
 
-### From 2.19.1 to 2.19.2
+### From 2.19.1 to 2.20.0
 
 #### Fixes
 
 - Fixed a regression from `2.18` in `-take` that caused it to
   prematurely signal an error on improper lists (#393).
+- The functions `-union`, `-intersection`, and `-difference` now
+  return proper sets, without duplicate elements (#397).
+- The function `-same-items?` now works on multisets (lists with
+  duplicate elements and/or different lengths) (#397).
+
+  For example, the following now returns non-`nil`:
+
+  ```el
+  (-same-items? '(1 1 2 3) '(1 2 3))
+  ```
+
+#### New features
+
+- The function `-contains?` now returns the matching tail of the list
+  instead of just `t`, similarly to `member` (#397).
 
 ### From 2.19.0 to 2.19.1
 

--- a/dash.texi
+++ b/dash.texi
@@ -1884,46 +1884,23 @@ Alias: @code{-only-some-p}
 Return non-@code{nil} if @var{list} contains @var{element}.
 
 The test for equality is done with @code{equal}, or with @code{-compare-fn}
-if that's non-@code{nil}.
+if that is non-@code{nil}.  As with @code{member}, the return value is
+actually the tail of @var{list} whose car is @var{element}.
 
-Alias: @code{-contains-p}
+Alias: @code{-contains-p}.
 
 @example
 @group
 (-contains? '(1 2 3) 1)
-    @result{} t
+    @result{} (1 2 3)
 @end group
 @group
 (-contains? '(1 2 3) 2)
-    @result{} t
+    @result{} (2 3)
 @end group
 @group
 (-contains? '(1 2 3) 4)
-    @result{} nil
-@end group
-@end example
-@end defun
-
-@anchor{-same-items?}
-@defun -same-items? (list list2)
-Return true if @var{list} and @var{list2} has the same items.
-
-The order of the elements in the lists does not matter.
-
-Alias: @code{-same-items-p}
-
-@example
-@group
-(-same-items? '(1 2 3) '(1 2 3))
-    @result{} t
-@end group
-@group
-(-same-items? '(1 2 3) '(3 2 1))
-    @result{} t
-@end group
-@group
-(-same-items? '(1 2 3) '(1 2 3 4))
-    @result{} nil
+    @result{} ()
 @end group
 @end example
 @end defun
@@ -2566,10 +2543,11 @@ permutation to @var{list} sorts it in descending order.
 Operations pretending lists are sets.
 
 @anchor{-union}
-@defun -union (list list2)
-Return a new list of all elements appearing in either @var{list1} or @var{list2}.
-Equality is defined by the value of @code{-compare-fn} if non-@code{nil};
-otherwise @code{equal}.
+@defun -union (list1 list2)
+Return a new list of distinct elements appearing in either @var{list1} or @var{list2}.
+
+The test for equality is done with @code{equal}, or with @code{-compare-fn}
+if that is non-@code{nil}.
 
 @example
 @group
@@ -2577,21 +2555,22 @@ otherwise @code{equal}.
     @result{} (1 2 3 4 5)
 @end group
 @group
-(-union '(1 2 3 4) ())
-    @result{} (1 2 3 4)
+(-union '(1 2 2 4) ())
+    @result{} (1 2 4)
 @end group
 @group
-(-union '(1 1 2 2) '(3 2 1))
-    @result{} (1 1 2 2 3)
+(-union '(1 1 2 2) '(4 4 3 2 1))
+    @result{} (1 2 4 3)
 @end group
 @end example
 @end defun
 
 @anchor{-difference}
-@defun -difference (list list2)
-Return a new list with only the members of @var{list} that are not in @var{list2}.
-The test for equality is done with @code{equal},
-or with @code{-compare-fn} if that's non-@code{nil}.
+@defun -difference (list1 list2)
+Return a new list with the distinct members of @var{list1} that are not in @var{list2}.
+
+The test for equality is done with @code{equal}, or with @code{-compare-fn}
+if that is non-@code{nil}.
 
 @example
 @group
@@ -2610,10 +2589,11 @@ or with @code{-compare-fn} if that's non-@code{nil}.
 @end defun
 
 @anchor{-intersection}
-@defun -intersection (list list2)
-Return a new list of the elements appearing in both @var{list1} and @var{list2}.
-Equality is defined by the value of @code{-compare-fn} if non-@code{nil};
-otherwise @code{equal}.
+@defun -intersection (list1 list2)
+Return a new list of distinct elements appearing in both @var{list1} and @var{list2}.
+
+The test for equality is done with @code{equal}, or with @code{-compare-fn}
+if that is non-@code{nil}.
 
 @example
 @group
@@ -2625,8 +2605,8 @@ otherwise @code{equal}.
     @result{} ()
 @end group
 @group
-(-intersection '(1 2 3 4) '(3 4 5 6))
-    @result{} (3 4)
+(-intersection '(1 2 2 3) '(4 3 3 2))
+    @result{} (2 3)
 @end group
 @end example
 @end defun
@@ -2669,11 +2649,12 @@ Return the permutations of @var{list}.
 
 @anchor{-distinct}
 @defun -distinct (list)
-Return a new list with all duplicates removed.
-The test for equality is done with @code{equal},
-or with @code{-compare-fn} if that's non-@code{nil}.
+Return a copy of @var{list} with all duplicate elements removed.
 
-Alias: @code{-uniq}
+The test for equality is done with @code{equal}, or with @code{-compare-fn}
+if that is non-@code{nil}.
+
+Alias: @code{-uniq}.
 
 @example
 @group
@@ -2681,12 +2662,39 @@ Alias: @code{-uniq}
     @result{} ()
 @end group
 @group
-(-distinct '(1 2 2 4))
-    @result{} (1 2 4)
+(-distinct '(1 1 2 3 3))
+    @result{} (1 2 3)
 @end group
 @group
 (-distinct '(t t t))
     @result{} (t)
+@end group
+@end example
+@end defun
+
+@anchor{-same-items?}
+@defun -same-items? (list1 list2)
+Return non-@code{nil} if @var{list1} and @var{list2} have the same distinct elements.
+
+The order of the elements in the lists does not matter.  The
+lists may be of different lengths, i.e., contain duplicate
+elements.  The test for equality is done with @code{equal}, or with
+@code{-compare-fn} if that is non-@code{nil}.
+
+Alias: @code{-same-items-p}.
+
+@example
+@group
+(-same-items? '(1 2 3) '(1 2 3))
+    @result{} t
+@end group
+@group
+(-same-items? '(1 1 2 3) '(3 3 2 1))
+    @result{} t
+@end group
+@group
+(-same-items? '(1 2 3) '(1 2 3 4))
+    @result{} nil
 @end group
 @end example
 @end defun

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -27,6 +27,7 @@
 
 (require 'dash)
 (require 'dash-defs "dev/dash-defs")
+(require 'ert)
 
 (eval-when-compile
   ;; TODO: Emacs 24.3 first introduced `setf', so remove this when
@@ -771,18 +772,21 @@ value rather than consuming a list to produce a single value."
     (--only-some? (> it 2) '(1 2 3)) => t)
 
   (defexamples -contains?
-    (-contains? '(1 2 3) 1) => t
-    (-contains? '(1 2 3) 2) => t
-    (-contains? '(1 2 3) 4) => nil
-    (-contains? '() 1) => nil
-    (-contains? '() '()) => nil)
-
-  (defexamples -same-items?
-    (-same-items? '(1 2 3) '(1 2 3)) => t
-    (-same-items? '(1 2 3) '(3 2 1)) => t
-    (-same-items? '(1 2 3) '(1 2 3 4)) => nil
-    (-same-items? '((a . 1) (b . 2)) '((a . 1) (b . 2))) => t
-    (-same-items? '(1 2 3) '(2 3 1)) => t)
+    (-contains? '(1 2 3) 1) => '(1 2 3)
+    (-contains? '(1 2 3) 2) => '(2 3)
+    (-contains? '(1 2 3) 4) => '()
+    (-contains? '() 1) => '()
+    (-contains? '() '()) => '()
+    (-contains? `(,(string ?a)) "a") => '("a")
+    (-contains? '(a a) 'a) => '(a a)
+    (-contains? '(b b a a) 'a) => '(a a)
+    (-contains? '(a a b b) 'a) => '(a a b b)
+    (let ((-compare-fn #'eq)) (-contains? `(,(string ?a)) "a")) => '()
+    (let ((-compare-fn #'string=)) (-contains? '(a) 'b)) => '()
+    (let ((-compare-fn #'string=)) (-contains? '(a) "a")) => '(a)
+    (let ((-compare-fn #'string=)) (-contains? '("a") 'a)) => '("a")
+    (let ((-compare-fn #'string=)) (-contains? '(a "a") 'a)) => '(a "a")
+    (let ((-compare-fn #'string=)) (-contains? '("a" a) 'a)) => '("a" a))
 
   (defexamples -is-prefix?
     (-is-prefix? '(1 2 3) '(1 2 3 4 5)) => t
@@ -1112,18 +1116,77 @@ related predicates."
 
   (defexamples -union
     (-union '(1 2 3) '(3 4 5))  => '(1 2 3 4 5)
-    (-union '(1 2 3 4) '())  => '(1 2 3 4)
-    (-union '(1 1 2 2) '(3 2 1))  => '(1 1 2 2 3))
+    (-union '(1 2 2 4) '())  => '(1 2 4)
+    (-union '(1 1 2 2) '(4 4 3 2 1))  => '(1 2 4 3)
+    (-union '() '()) => '()
+    (-union '() '(a)) => '(a)
+    (-union '() '(a a)) => '(a)
+    (-union '() '(a a b)) => '(a b)
+    (-union '() '(a b a)) => '(a b)
+    (-union '() '(b a a)) => '(b a)
+    (-union '(a) '()) => '(a)
+    (-union '(a a) '()) => '(a)
+    (-union '(a a b) '()) => '(a b)
+    (-union '(a b a) '()) => '(a b)
+    (-union '(b a a) '()) => '(b a)
+    (let ((dash--short-list-length 0)) (-union '() '(a))) => '(a)
+    (let ((dash--short-list-length 0)) (-union '() '(a a))) => '(a)
+    (let ((dash--short-list-length 0)) (-union '() '(a a b))) => '(a b)
+    (let ((dash--short-list-length 0)) (-union '() '(a b a))) => '(a b)
+    (let ((dash--short-list-length 0)) (-union '() '(b a a))) => '(b a)
+    (let ((dash--short-list-length 0)) (-union '(a) '())) => '(a)
+    (let ((dash--short-list-length 0)) (-union '(a a) '())) => '(a)
+    (let ((dash--short-list-length 0)) (-union '(a a b) '())) => '(a b)
+    (let ((dash--short-list-length 0)) (-union '(a b a) '())) => '(a b)
+    (let ((dash--short-list-length 0)) (-union '(b a a) '())) => '(b a)
+    (let ((dash--short-list-length 0)) (-union '(a a b c c) '(e e d c b)))
+    => '(a b c e d)
+    (let ((-compare-fn #'string=)) (-union '(a "b") '("a" b))) => '(a "b")
+    (let ((-compare-fn #'string=)) (-union '("a" b) '(a "b"))) => '("a" b))
 
   (defexamples -difference
     (-difference '() '()) => '()
     (-difference '(1 2 3) '(4 5 6)) => '(1 2 3)
-    (-difference '(1 2 3 4) '(3 4 5 6)) => '(1 2))
+    (-difference '(1 2 3 4) '(3 4 5 6)) => '(1 2)
+    (-difference '() '(a)) => '()
+    (-difference '(a) '()) => '(a)
+    (-difference '(a) '(a)) => '()
+    (-difference '(a a) '()) => '(a)
+    (-difference '(a a) '(a)) => '()
+    (-difference '(a a) '(a a)) => '()
+    (-difference '(a a) '(b)) => '(a)
+    (-difference '(a b c c d a) '(c c b)) => '(a d)
+    (let ((dash--short-list-length 0)) (-difference '(a) '(a))) => '()
+    (let ((dash--short-list-length 0)) (-difference '(a a) '(a))) => '()
+    (let ((dash--short-list-length 0)) (-difference '(a a) '(a a))) => '()
+    (let ((dash--short-list-length 0)) (-difference '(a a) '(b))) => '(a)
+    (let ((dash--short-list-length 0)) (-difference '(a b c c d a) '(c c b)))
+    => '(a d)
+    (let ((-compare-fn #'string=)) (-difference '(a) '("a"))) => '()
+    (let ((-compare-fn #'string=)) (-difference '("a") '(a))) => '()
+    (let ((-compare-fn #'string=)) (-difference '(a "a") '(a))) => '()
+    (let ((-compare-fn #'string=)) (-difference '(a "a") '(b))) => '(a)
+    (let ((-compare-fn #'string=)) (-difference '("a") '(a a))) => '())
 
   (defexamples -intersection
     (-intersection '() '()) => '()
     (-intersection '(1 2 3) '(4 5 6)) => '()
-    (-intersection '(1 2 3 4) '(3 4 5 6)) => '(3 4))
+    (-intersection '(1 2 2 3) '(4 3 3 2)) => '(2 3)
+    (-intersection '() '(a)) => '()
+    (-intersection '(a) '()) => '()
+    (-intersection '(a) '(a)) => '(a)
+    (-intersection '(a a b) '(b a)) => '(a b)
+    (-intersection '(a b) '(b a a)) => '(a b)
+    (let ((dash--short-list-length 0)) (-intersection '(a) '(b))) => '()
+    (let ((dash--short-list-length 0)) (-intersection '(a) '(a))) => '(a)
+    (let ((dash--short-list-length 0)) (-intersection '(a a b) '(b b a)))
+    => '(a b)
+    (let ((dash--short-list-length 0)) (-intersection '(a a b) '(b a)))
+    => '(a b)
+    (let ((dash--short-list-length 0)) (-intersection '(a b) '(b a a)))
+    => '(a b)
+    (let ((-compare-fn #'string=)) (-intersection '(a) '("a")) => '(a))
+    (let ((-compare-fn #'string=)) (-intersection '("a") '(a)) => '("a")))
 
   (defexamples -powerset
     (-powerset '()) => '(nil)
@@ -1136,19 +1199,73 @@ related predicates."
 
   (defexamples -distinct
     (-distinct '()) => '()
-    (-distinct '(1 2 2 4)) => '(1 2 4)
+    (-distinct '(1 1 2 3 3)) => '(1 2 3)
     (-distinct '(t t t)) => '(t)
     (-distinct '(nil nil nil)) => '(nil)
-    (let ((-compare-fn nil))
-      (-distinct '((1) (2) (1) (1)))) => '((1) (2))
-    (let ((-compare-fn #'eq))
-      (-distinct '((1) (2) (1) (1)))) => '((1) (2) (1) (1))
-    (let ((-compare-fn #'eq))
-      (-distinct '(:a :b :a :a))) => '(:a :b)
-    (let ((-compare-fn #'eql))
-      (-distinct '(2.1 3.1 2.1 2.1))) => '(2.1 3.1)
+    (-uniq '((1) (2) (1) (1))) => '((1) (2))
+    (let ((-compare-fn #'eq)) (-uniq '((1) (2) (1) (1)))) => '((1) (2) (1) (1))
+    (let ((-compare-fn #'eq)) (-uniq '(:a :b :a :a))) => '(:a :b)
+    (let ((-compare-fn #'eql)) (-uniq '(2.1 3.1 2.1 2.1))) => '(2.1 3.1)
     (let ((-compare-fn #'string=))
-      (-distinct '(dash "dash" "ash" "cash" "bash"))) => '(dash "ash" "cash" "bash")))
+      (-uniq '(dash "dash" "ash" "cash" "bash")))
+    => '(dash "ash" "cash" "bash")
+    (let ((-compare-fn #'string=)) (-uniq '(a))) => '(a)
+    (let ((-compare-fn #'string=)) (-uniq '(a a))) => '(a)
+    (let ((-compare-fn #'string=)) (-uniq '(a b))) => '(a b)
+    (let ((-compare-fn #'string=)) (-uniq '(b a))) => '(b a)
+    (let ((-compare-fn #'string=)) (-uniq '(a "a"))) => '(a)
+    (let ((-compare-fn #'string=)) (-uniq '("a" a))) => '("a")
+    (let ((dash--short-list-length 0)) (-uniq '(a))) => '(a)
+    (let ((dash--short-list-length 0)) (-uniq '(a b))) => '(a b)
+    (let ((dash--short-list-length 0)) (-uniq '(b a))) => '(b a)
+    (let ((dash--short-list-length 0)) (-uniq '(a a))) => '(a)
+    (let ((dash--short-list-length 0)) (-uniq '(a a b))) => '(a b)
+    (let ((dash--short-list-length 0)) (-uniq '(a b a))) => '(a b)
+    (let ((dash--short-list-length 0)) (-uniq '(b a a))) => '(b a)
+    (let ((dash--short-list-length 0)
+          (-compare-fn #'eq))
+      (-uniq (list (string ?a) (string ?a))))
+    => '("a" "a")
+    (let ((dash--short-list-length 0)
+          (-compare-fn #'eq)
+          (a (string ?a)))
+      (-uniq (list a a)))
+    => '("a"))
+
+  (defexamples -same-items?
+    (-same-items? '(1 2 3) '(1 2 3)) => t
+    (-same-items? '(1 1 2 3) '(3 3 2 1)) => t
+    (-same-items? '(1 2 3) '(1 2 3 4)) => nil
+    (-same-items? '((a . 1) (b . 2)) '((a . 1) (b . 2))) => t
+    (-same-items? '() '()) => t
+    (-same-items? '() '(a)) => nil
+    (-same-items? '(a) '()) => nil
+    (-same-items? '(a) '(a)) => t
+    (-same-items? '(a) '(b)) => nil
+    (-same-items? '(a) '(a a)) => t
+    (-same-items? '(b) '(a a)) => nil
+    (-same-items? '(a) '(a b)) => nil
+    (-same-items? '(a a) '(a)) => t
+    (-same-items? '(a a) '(b)) => nil
+    (-same-items? '(a a) '(a b)) => nil
+    (-same-items? '(a b) '(a)) => nil
+    (-same-items? '(a b) '(a a)) => nil
+    (-same-items? '(a a) '(a a)) => t
+    (-same-items? '(a a b) '(b b a a)) => t
+    (-same-items? '(b b a a) '(a a b)) => t
+    (let ((dash--short-list-length 0)) (-same-items? '(a) '(a))) => t
+    (let ((dash--short-list-length 0)) (-same-items? '(a) '(b))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a) '(a a))) => t
+    (let ((dash--short-list-length 0)) (-same-items? '(b) '(a a))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a) '(a b))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a a) '(a))) => t
+    (let ((dash--short-list-length 0)) (-same-items? '(a a) '(b))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a a) '(a b))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a b) '(a))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a b) '(a a))) => nil
+    (let ((dash--short-list-length 0)) (-same-items? '(a a) '(a a))) => t
+    (let ((dash--short-list-length 0)) (-same-items? '(a a b) '(b b a a))) => t
+    (let ((dash--short-list-length 0)) (-same-items? '(b b a a) '(a a b))) => t))
 
 (def-example-group "Other list operations"
   "Other list functions not fit to be classified elsewhere."
@@ -2136,5 +2253,48 @@ or readability."
                   (funcall (-compose g (-partial 'nth 1)) input))
            (equal (funcall (-compose (-prodfn f g) (-prodfn ff gg)) input3)
                   (funcall (-prodfn (-compose f ff) (-compose g gg)) input3)))) => t))
+
+(ert-deftest dash--member-fn ()
+  "Test `dash--member-fn'."
+  (dolist (cmp '(nil equal))
+    (let ((-compare-fn cmp))
+      (should (eq (dash--member-fn) #'member))))
+  (let ((-compare-fn #'eq))
+    (should (eq (dash--member-fn) #'memq)))
+  (let ((-compare-fn #'eql))
+    (should (eq (dash--member-fn) #'memql)))
+  (let* ((-compare-fn #'string=)
+         (member (dash--member-fn)))
+    (should-not (memq member '(member memq memql)))
+    (should-not (funcall member "foo" ()))
+    (should-not (funcall member "foo" '(bar)))
+    (should (equal (funcall member "foo" '(foo bar)) '(foo bar)))
+    (should (equal (funcall member "foo" '(bar foo)) '(foo)))))
+
+(ert-deftest dash--hash-test-fn ()
+  "Test `dash--hash-test-fn'."
+  (let ((-compare-fn nil))
+    (should (eq (dash--hash-test-fn) #'equal)))
+  (dolist (cmp '(equal eq eql))
+    (let ((-compare-fn cmp))
+      (should (eq (dash--hash-test-fn) cmp))))
+  (let ((-compare-fn #'string=))
+    (should-not (dash--hash-test-fn))))
+
+(ert-deftest dash--size+ ()
+  "Test `dash--size+'."
+  (dotimes (a 3)
+    (dotimes (b 3)
+      (should (= (dash--size+ a b) (+ a b)))))
+  (should (= (dash--size+ (- most-positive-fixnum 10) 5)
+             (- most-positive-fixnum 5)))
+  (should (= (dash--size+ (1- most-positive-fixnum) 0)
+             (1- most-positive-fixnum)))
+  (dotimes (i 2)
+    (should (= (dash--size+ (1- most-positive-fixnum) (1+ i))
+               most-positive-fixnum)))
+  (dotimes (i 3)
+    (should (= (dash--size+ most-positive-fixnum i)
+               most-positive-fixnum))))
 
 ;;; examples.el ends here


### PR DESCRIPTION
This improves the performance and correctness of clients of `-compare-fn`, but I'd like a review before merging because there are some slight changes in return values:

- `-contains?` now returns the matching tail of the list, just like `member`, instead of just `t`.
- `-union`, `-intersection`, and `-difference` now always return proper sets, without duplicates.
- ~~`-difference` continues to return multisets, with duplicates, because its docstring promises to return the same list it was given, modulo its intersection with another list.~~
- `-same-items?` now accepts multisets, i.e. lists with duplicates and/or different lengths, just like `seq-set-equal-p`.

Do these changes sound reasonable to you?

Should `-difference` also return a proper set, without duplicates?  I think its docstring can be interpreted either way, and so far it's been categorised as a set operation, so I don't think it's unreasonable for it to return a set.

Cc: @rejeep