### PR TITLE
Add -comment macro

### DIFF
--- a/dash.el
+++ b/dash.el
@@ -49,6 +49,11 @@
   :group 'lisp
   :prefix "dash-")
 
+;; Clojure style comment macro
+(defmacro -comment (&rest _)
+  "Ignore body, yield nil."
+  nil)
+
 (defmacro !cons (car cdr)
   "Destructive: Set CDR to the cons of CAR and CDR."
   (declare (debug (form symbolp)))


### PR DESCRIPTION
I find the `-comment` macro to be as usefule in Elisp, as the [commen](https://clojuredocs.org/clojure.core/comment) macro is in Clojure. I think it deserves to be part of the dash.el.