### PR TITLE
add ->>as-> function for use with ->> 

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ or readability.
 * [`->>`](#--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [`-->`](#---x-rest-forms) `(x &rest forms)`
 * [`-as->`](#-as--value-variable-rest-forms) `(value variable &rest forms)`
+* [`->>as->`](#->>as->variable-rest-forms-value) `(value forms ... value)`
 * [`-some->`](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [`-some->>`](#-some--x-optional-form-rest-more) `(x &optional form &rest more)`
 * [`-some-->`](#-some---expr-rest-forms) `(expr &rest forms)`
@@ -2526,6 +2527,17 @@ In the first form, bind `variable` to `value`.  In the second form, bind
 (-as-> 3 my-var (1+ my-var) (list my-var) (mapcar (lambda (ele) (* 2 ele)) my-var)) ;; => (8)
 (-as-> 3 my-var 1+) ;; => 4
 (-as-> 3 my-var) ;; => 3
+```
+
+#### ->>as-> (variable forms ... value)
+Ending with VALUE, thread VARIABLE through all the other FORMS.
+Variant of `-as->` but intended for use with `->>`.
+
+```el
+(->>as-> i (+ i 1) 1) ;; => 2
+;; ^ unintuitive on its own.
+(->> 1 (->>as-> i (+ i 1))) ;; => 2
+(->> "def" (->>as-> string (concat "abc" string "ghi"))) ;; => "abcdefghi"
 ```
 
 #### -some-> `(x &optional form &rest more)`

--- a/dash.el
+++ b/dash.el
@@ -2127,6 +2127,19 @@ VARIABLE to the result of the first form, and so forth."
               ,variable
               ,@(cdr forms)))))
 
+(defmacro ->>as-> (variable &rest forms)
+  "Ending with VALUE, thread VARIABLE through all the other FORMS.
+Variant of `-as->' but intended for use with `->>'.
+
+\(fn VARIABLE FORMS ... VALUE)"
+  (if (null forms)
+      (error "No Value nor Forms given!")
+    (let ((val (car (last forms)))
+          (args (-butlast forms)))
+      (if (null args)
+          `,val
+        `(-as-> ,val ,variable ,@args)))))
+
 (defmacro -some-> (x &optional form &rest more)
   "When expr is non-nil, thread it through the first form (via `->'),
 and when that result is non-nil, through the next form, etc."

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -2064,6 +2064,14 @@ or readability."
     (-as-> "def" string (concat "abc" string "ghi") upcase) => "ABCDEFGHI"
     (-as-> "def" string (concat "abc" string "ghi") (upcase string)) => "ABCDEFGHI")
 
+  (defexamples ->>as->
+    (->>as-> i 1) => 1
+    (->>as-> i (+ i 1) 1) => 2
+    (->> 1 (->>as-> i (+ i 1))) => 2
+    (->> "def" (->>as-> string (concat "abc" string "ghi"))) => "abcdefghi"
+    (->> "def" (->>as-> string (concat "abc" string "ghi")) upcase) => "ABCDEFGHI"
+    (->> "def" (->>as-> string (concat "abc" string "ghi") (upcase string))) => "ABCDEFGHI")
+
   (defexamples -some->
     (-some-> '(2 3 5)) => '(2 3 5)
     (-some-> 5 square) => 25


### PR DESCRIPTION
seems better and more consistent to use 
```lisp
(->> 1 (->>as-> i (+ i 1)))
```
rather than
```lisp
(->> 1 ((lambda (i) (+ i 1)))
```
\+ there's less consing of misc. closures to mimic the same functionality as `-as->`